### PR TITLE
Set phar alias

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,7 @@
 {
     "main": "bdi",
-    "output" : ".dist/bdi.phar",
+    "output": ".dist/bdi.phar",
+    "alias": "bdi.phar",
     "files": [
         "bdi"
     ],


### PR DESCRIPTION
Allows removing the .phar extension and still being able to run the file