### PR TITLE
Revert PHP 7.1 support

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           extensions: zip
           coverage: none
       - id: composer-cache
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           extensions: zip
           coverage: none
       - id: composer-cache
@@ -41,14 +41,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
       - run: composer install --no-interaction
-      - run: vendor/bin/phpstan analyse
+      - run: vendor/bin/phpstan analyse --error-format=github
   psalm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           extensions: zip
           coverage: none
       - id: composer-cache
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           extensions: zip
           coverage: none
       - id: composer-cache
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.1
+          php-version: 7.2
           extensions: zip
           coverage: none
           tools: phive

--- a/composer.json
+++ b/composer.json
@@ -27,29 +27,28 @@
         "bdi"
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
         "myclabs/php-enum": "^1.7",
-        "symfony/console": "^4.4|^5.0",
-        "symfony/filesystem": "^4.4|^5.0",
-        "symfony/http-client": "^4.4|^5.0",
-        "symfony/polyfill-php72": "^1.20",
+        "symfony/console": "^5.1",
+        "symfony/filesystem": "^5.1",
+        "symfony/http-client": "^5.1",
         "symfony/polyfill-php80": "^1.18",
-        "symfony/process": "^4.4|^5.0",
-        "thecodingmachine/safe": "^0.1|^1.1"
+        "symfony/process": "^5.1",
+        "thecodingmachine/safe": "^1.1"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^6.0|^8.0",
-        "phpstan/phpstan": "^0.10|^0.12",
-        "phpstan/phpstan-phpunit": "^0.10|^0.12",
-        "phpstan/phpstan-strict-rules": "^0.10|^0.12",
-        "phpunit/phpunit": "^7.5|^8.5",
+        "doctrine/coding-standard": "^8.0",
+        "phpstan/phpstan": "^0.12.36",
+        "phpstan/phpstan-phpunit": "^0.12.16",
+        "phpstan/phpstan-strict-rules": "^0.12.5",
+        "phpunit/phpunit": "^8.5",
         "psalm/plugin-phpunit": "^0.12|^0.13",
         "roave/security-advisories": "dev-master",
-        "thecodingmachine/phpstan-safe-rule": "^0.1|^1.0",
-        "thecodingmachine/phpstan-strict-rules": "^0.10|^0.12",
+        "thecodingmachine/phpstan-safe-rule": "^1.0",
+        "thecodingmachine/phpstan-strict-rules": "^0.12.0",
         "vimeo/psalm": "^3.18|^4.0"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,9 +4,6 @@ parameters:
 		- src
 		- tests
 		- bdi
-	ignoreErrors:
-		- '#In method \"DBrekelmans\\BrowserDriverInstaller\\Command\\DetectCommand::execute\", caught \"Throwable\" must be rethrown#'
-		- '#Parameter \#2 $files of method Phar::extractTo() expects array|string, null given.#'
 
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Archive/Extractor.php
+++ b/src/Archive/Extractor.php
@@ -13,10 +13,10 @@ interface Extractor
      *
      * @throws Unsupported
      */
-    public function extract(string $archive, string $destination) : array;
+    public function extract(string $archive, string $destination): array;
 
     /**
      * @return string[]
      */
-    public function getSupportedExtensions() : array;
+    public function getSupportedExtensions(): array;
 }

--- a/src/Archive/MultiExtractor.php
+++ b/src/Archive/MultiExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Archive;
 
 use DBrekelmans\BrowserDriverInstaller\Exception\Unsupported;
+
 use function array_merge;
 use function array_unique;
 use function in_array;
@@ -22,7 +23,7 @@ final class MultiExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function extract(string $archive, string $destination) : array
+    public function extract(string $archive, string $destination): array
     {
         $pathParts = pathinfo($archive);
 
@@ -42,12 +43,12 @@ final class MultiExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function getSupportedExtensions() : array
+    public function getSupportedExtensions(): array
     {
         return $this->supportedExtensions;
     }
 
-    public function register(Extractor $extractor) : void
+    public function register(Extractor $extractor): void
     {
         $this->registeredExtractors[] = $extractor;
         $this->supportedExtensions    = array_unique(array_merge($this->supportedExtensions, $extractor->getSupportedExtensions()));

--- a/src/Archive/TarGzExtractor.php
+++ b/src/Archive/TarGzExtractor.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Archive;
 
 use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
-use Phar;
 use PharData;
 use PharFileInfo;
+
 use const DIRECTORY_SEPARATOR;
 
 final class TarGzExtractor implements Extractor
@@ -15,11 +15,10 @@ final class TarGzExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function extract(string $archive, string $destination) : array
+    public function extract(string $archive, string $destination): array
     {
         $tarGzData = new PharData($archive);
-        /** @var Phar $tarData */
-        $tarData = $tarGzData->decompress();
+        $tarData   = $tarGzData->decompress();
         /** @phpstan-ignore-next-line */
         $tarData->extractTo($destination, null, true);
 
@@ -38,7 +37,7 @@ final class TarGzExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function getSupportedExtensions() : array
+    public function getSupportedExtensions(): array
     {
         return ['gz'];
     }

--- a/src/Archive/ZipExtractor.php
+++ b/src/Archive/ZipExtractor.php
@@ -6,8 +6,10 @@ namespace DBrekelmans\BrowserDriverInstaller\Archive;
 
 use RuntimeException;
 use ZipArchive;
-use const DIRECTORY_SEPARATOR;
+
 use function Safe\sprintf;
+
+use const DIRECTORY_SEPARATOR;
 
 final class ZipExtractor implements Extractor
 {
@@ -22,7 +24,7 @@ final class ZipExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function extract(string $archive, string $destination) : array
+    public function extract(string $archive, string $destination): array
     {
         $success = $this->zipArchive->open($archive);
 
@@ -53,7 +55,7 @@ final class ZipExtractor implements Extractor
     /**
      * @inheritDoc
      */
-    public function getSupportedExtensions() : array
+    public function getSupportedExtensions(): array
     {
         return ['zip'];
     }

--- a/src/Browser/Browser.php
+++ b/src/Browser/Browser.php
@@ -25,17 +25,17 @@ final class Browser
         $this->operatingSystem = $operatingSystem;
     }
 
-    public function name() : BrowserName
+    public function name(): BrowserName
     {
         return $this->name;
     }
 
-    public function version() : Version
+    public function version(): Version
     {
         return $this->version;
     }
 
-    public function operatingSystem() : OperatingSystem
+    public function operatingSystem(): OperatingSystem
     {
         return $this->operatingSystem;
     }

--- a/src/Browser/BrowserFactory.php
+++ b/src/Browser/BrowserFactory.php
@@ -22,7 +22,7 @@ final class BrowserFactory
         $this->versionResolverFactory = $versionResolverFactory;
     }
 
-    public function createFromNameAndOperatingSystem(BrowserName $name, OperatingSystem $operatingSystem) : Browser
+    public function createFromNameAndOperatingSystem(BrowserName $name, OperatingSystem $operatingSystem): Browser
     {
         $pathResolver = $this->pathResolverFactory->createFromName($name);
         $path         = $pathResolver->from($operatingSystem);
@@ -34,7 +34,7 @@ final class BrowserFactory
         BrowserName $name,
         OperatingSystem $operatingSystem,
         string $path
-    ) : Browser {
+    ): Browser {
         $versionResolver = $this->versionResolverFactory->createFromName($name);
         $version         = $versionResolver->from($operatingSystem, $path);
 

--- a/src/Browser/Chromium/Command.php
+++ b/src/Browser/Chromium/Command.php
@@ -9,7 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Command\BrowserCommand;
 
 final class Command extends BrowserCommand
 {
-    protected static function browserName() : BrowserName
+    protected static function browserName(): BrowserName
     {
         return BrowserName::CHROMIUM();
     }

--- a/src/Browser/Chromium/PathResolver.php
+++ b/src/Browser/Chromium/PathResolver.php
@@ -8,11 +8,12 @@ use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
 use DBrekelmans\BrowserDriverInstaller\Browser\PathResolver as PathResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
+
 use function Safe\sprintf;
 
 class PathResolver implements PathResolverInterface
 {
-    public function from(OperatingSystem $operatingSystem) : string
+    public function from(OperatingSystem $operatingSystem): string
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             return 'chromium';
@@ -29,7 +30,7 @@ class PathResolver implements PathResolverInterface
         throw NotImplemented::feature(sprintf('Resolving path on %s', $operatingSystem->getValue()));
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::CHROMIUM());
     }

--- a/src/Browser/Chromium/VersionResolver.php
+++ b/src/Browser/Chromium/VersionResolver.php
@@ -13,6 +13,7 @@ use DBrekelmans\BrowserDriverInstaller\Version;
 use InvalidArgumentException;
 use RuntimeException;
 use Safe\Exceptions\StringsException;
+
 use function Safe\sprintf;
 
 final class VersionResolver implements VersionResolverInterface
@@ -32,7 +33,7 @@ final class VersionResolver implements VersionResolverInterface
         $this->commandLineEnvironment = $commandLineEnvironment;
     }
 
-    public function from(OperatingSystem $operatingSystem, string $path) : Version
+    public function from(OperatingSystem $operatingSystem, string $path): Version
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             return $this->getVersionFromCommandLine(sprintf('%s --version', $path));
@@ -64,12 +65,12 @@ final class VersionResolver implements VersionResolverInterface
         );
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::CHROMIUM());
     }
 
-    private function getVersionFromCommandLine(string $command) : Version
+    private function getVersionFromCommandLine(string $command): Version
     {
         try {
             $commandOutput = $this->commandLineEnvironment->getCommandLineSuccessfulOutput($command);
@@ -94,7 +95,7 @@ final class VersionResolver implements VersionResolverInterface
      *
      * @throws StringsException
      */
-    private static function getWindowsCommandsForVersion() : array
+    private static function getWindowsCommandsForVersion(): array
     {
         $commands = [];
         foreach ([self::REG_KEY_STABLE, self::REG_KEY_BETA, self::REG_KEY_DEV] as $regKey) {

--- a/src/Browser/Firefox/Command.php
+++ b/src/Browser/Firefox/Command.php
@@ -9,7 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Command\BrowserCommand;
 
 final class Command extends BrowserCommand
 {
-    protected static function browserName() : BrowserName
+    protected static function browserName(): BrowserName
     {
         return BrowserName::FIREFOX();
     }

--- a/src/Browser/Firefox/PathResolver.php
+++ b/src/Browser/Firefox/PathResolver.php
@@ -8,11 +8,12 @@ use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
 use DBrekelmans\BrowserDriverInstaller\Browser\PathResolver as PathResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
+
 use function Safe\sprintf;
 
 final class PathResolver implements PathResolverInterface
 {
-    public function from(OperatingSystem $operatingSystem) : string
+    public function from(OperatingSystem $operatingSystem): string
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             return 'firefox';
@@ -29,7 +30,7 @@ final class PathResolver implements PathResolverInterface
         throw NotImplemented::feature(sprintf('Resolving path on %s', $operatingSystem->getValue()));
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::FIREFOX());
     }

--- a/src/Browser/Firefox/VersionResolver.php
+++ b/src/Browser/Firefox/VersionResolver.php
@@ -11,6 +11,7 @@ use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Version;
 use InvalidArgumentException;
+
 use function Safe\sprintf;
 
 final class VersionResolver implements VersionResolverInterface
@@ -23,7 +24,7 @@ final class VersionResolver implements VersionResolverInterface
         $this->commandLineEnvironment = $commandLineEnvironment;
     }
 
-    public function from(OperatingSystem $operatingSystem, string $path) : Version
+    public function from(OperatingSystem $operatingSystem, string $path): Version
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             return $this->getVersionFromCommandLine(sprintf('%s --version', $path));
@@ -47,12 +48,12 @@ final class VersionResolver implements VersionResolverInterface
         );
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::FIREFOX());
     }
 
-    private function getVersionFromCommandLine(string $command) : Version
+    private function getVersionFromCommandLine(string $command): Version
     {
         try {
             $commandOutput = $this->commandLineEnvironment->getCommandLineSuccessfulOutput($command);

--- a/src/Browser/GoogleChrome/Command.php
+++ b/src/Browser/GoogleChrome/Command.php
@@ -9,7 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Command\BrowserCommand;
 
 final class Command extends BrowserCommand
 {
-    protected static function browserName() : BrowserName
+    protected static function browserName(): BrowserName
     {
         return BrowserName::GOOGLE_CHROME();
     }

--- a/src/Browser/GoogleChrome/PathResolver.php
+++ b/src/Browser/GoogleChrome/PathResolver.php
@@ -8,6 +8,7 @@ use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
 use DBrekelmans\BrowserDriverInstaller\Browser\PathResolver as PathResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
+
 use function Safe\sprintf;
 
 final class PathResolver implements PathResolverInterface
@@ -15,7 +16,7 @@ final class PathResolver implements PathResolverInterface
     /**
      * @throws NotImplemented
      */
-    public function from(OperatingSystem $operatingSystem) : string
+    public function from(OperatingSystem $operatingSystem): string
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             // TODO: command -v google-chrome
@@ -35,7 +36,7 @@ final class PathResolver implements PathResolverInterface
         throw NotImplemented::feature(sprintf('Resolving path on %s', $operatingSystem->getValue()));
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::GOOGLE_CHROME());
     }

--- a/src/Browser/GoogleChrome/VersionResolver.php
+++ b/src/Browser/GoogleChrome/VersionResolver.php
@@ -12,6 +12,7 @@ use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Version;
 use InvalidArgumentException;
 use Safe\Exceptions\StringsException;
+
 use function Safe\sprintf;
 
 final class VersionResolver implements VersionResolverInterface
@@ -31,7 +32,7 @@ final class VersionResolver implements VersionResolverInterface
         $this->commandLineEnvironment = $commandLineEnvironment;
     }
 
-    public function from(OperatingSystem $operatingSystem, string $path) : Version
+    public function from(OperatingSystem $operatingSystem, string $path): Version
     {
         if ($operatingSystem->equals(OperatingSystem::LINUX())) {
             return $this->getVersionFromCommandLine(sprintf('%s --version', $path));
@@ -64,12 +65,12 @@ final class VersionResolver implements VersionResolverInterface
         );
     }
 
-    public function supports(BrowserName $browserName) : bool
+    public function supports(BrowserName $browserName): bool
     {
         return $browserName->equals(BrowserName::GOOGLE_CHROME());
     }
 
-    private function getVersionFromCommandLine(string $command) : Version
+    private function getVersionFromCommandLine(string $command): Version
     {
         try {
             $commandOutput = $this->commandLineEnvironment->getCommandLineSuccessfulOutput($command);
@@ -94,7 +95,7 @@ final class VersionResolver implements VersionResolverInterface
      *
      * @throws StringsException
      */
-    private static function getWindowsCommandsForVersion() : array
+    private static function getWindowsCommandsForVersion(): array
     {
         $commands = [];
         foreach ([self::REG_KEY_STABLE, self::REG_KEY_BETA, self::REG_KEY_DEV] as $regKey) {

--- a/src/Browser/PathResolver.php
+++ b/src/Browser/PathResolver.php
@@ -8,7 +8,7 @@ use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 
 interface PathResolver
 {
-    public function from(OperatingSystem $operatingSystem) : string;
+    public function from(OperatingSystem $operatingSystem): string;
 
-    public function supports(BrowserName $browserName) : bool;
+    public function supports(BrowserName $browserName): bool;
 }

--- a/src/Browser/PathResolverFactory.php
+++ b/src/Browser/PathResolverFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Browser;
 
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+
 use function get_class;
 use function Safe\sprintf;
 
@@ -19,7 +20,7 @@ final class PathResolverFactory
     /**
      * @throws NotImplemented If no path resolver is implemented for browser.
      */
-    public function createFromName(BrowserName $browserName) : PathResolver
+    public function createFromName(BrowserName $browserName): PathResolver
     {
         foreach ($this->pathResolvers as $pathResolver) {
             if ($pathResolver->supports($browserName)) {
@@ -32,7 +33,7 @@ final class PathResolverFactory
         );
     }
 
-    public function register(PathResolver $pathResolver) : void
+    public function register(PathResolver $pathResolver): void
     {
         $this->pathResolvers[get_class($pathResolver)] = $pathResolver;
     }

--- a/src/Browser/VersionResolver.php
+++ b/src/Browser/VersionResolver.php
@@ -15,10 +15,10 @@ interface VersionResolver
      * @throws RuntimeException If the version could not be resolved.
      * @throws NotImplemented If the operating system is not yet supported.
      */
-    public function from(OperatingSystem $operatingSystem, string $path) : Version;
+    public function from(OperatingSystem $operatingSystem, string $path): Version;
 
     /**
      * TODO: Refactor to supports(OperatingSystem $operatingSystem).
      */
-    public function supports(BrowserName $browserName) : bool;
+    public function supports(BrowserName $browserName): bool;
 }

--- a/src/Browser/VersionResolverFactory.php
+++ b/src/Browser/VersionResolverFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Browser;
 
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+
 use function get_class;
 use function Safe\sprintf;
 
@@ -19,7 +20,7 @@ final class VersionResolverFactory
     /**
      * @throws NotImplemented If no version resolver is implemented for browser.
      */
-    public function createFromName(BrowserName $browserName) : VersionResolver
+    public function createFromName(BrowserName $browserName): VersionResolver
     {
         foreach ($this->versionResolvers as $versionResolver) {
             if ($versionResolver->supports($browserName)) {
@@ -32,7 +33,7 @@ final class VersionResolverFactory
         );
     }
 
-    public function register(VersionResolver $versionResolver) : void
+    public function register(VersionResolver $versionResolver): void
     {
         $this->versionResolvers[get_class($versionResolver)] = $versionResolver;
     }

--- a/src/Command/BrowserCommand.php
+++ b/src/Command/BrowserCommand.php
@@ -14,12 +14,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+
 use function Safe\sprintf;
 
 abstract class BrowserCommand extends Command
 {
-    public const PREFIX  = 'browser';
-    public const SUCCESS = 0;
+    public const PREFIX = 'browser';
 
     /** @var Filesystem */
     protected $filesystem;
@@ -47,9 +47,9 @@ abstract class BrowserCommand extends Command
         parent::__construct(sprintf('%s:%s', self::PREFIX, static::browserName()->getValue()));
     }
 
-    abstract protected static function browserName() : BrowserName;
+    abstract protected static function browserName(): BrowserName;
 
-    final protected function configure() : void
+    final protected function configure(): void
     {
         $this->setDescription(sprintf('Helps you install the driver for %s.', static::browserName()->getValue()));
 
@@ -64,7 +64,7 @@ abstract class BrowserCommand extends Command
         );
     }
 
-    final protected function execute(InputInterface $input, OutputInterface $output) : int
+    final protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/DetectCommand.php
+++ b/src/Command/DetectCommand.php
@@ -13,20 +13,19 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
+
 use function Safe\sprintf;
 
 final class DetectCommand extends Command
 {
-    public const NAME    = 'detect';
-    public const FAILURE = 1;
-    public const SUCCESS = 0;
+    public const NAME = 'detect';
 
     public function __construct()
     {
         parent::__construct(self::NAME);
     }
 
-    protected function configure() : void
+    protected function configure(): void
     {
         $this->setDescription('Detects installed browsers and installs corresponding drivers.');
 
@@ -40,7 +39,7 @@ final class DetectCommand extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output) : int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/DriverCommand.php
+++ b/src/Command/DriverCommand.php
@@ -14,12 +14,12 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+
 use function Safe\sprintf;
 
 abstract class DriverCommand extends Command
 {
-    public const PREFIX  = 'driver';
-    public const SUCCESS = 0;
+    public const PREFIX = 'driver';
 
     /** @var VersionResolver */
     private $versionResolver;
@@ -37,9 +37,9 @@ abstract class DriverCommand extends Command
         parent::__construct(sprintf('%s:%s', self::PREFIX, static::driverName()->getValue()));
     }
 
-    abstract protected static function driverName() : DriverName;
+    abstract protected static function driverName(): DriverName;
 
-    final protected function configure() : void
+    final protected function configure(): void
     {
         $this->setDescription(sprintf('Helps you install the %s.', static::driverName()->getValue()));
 
@@ -54,7 +54,7 @@ abstract class DriverCommand extends Command
         );
     }
 
-    final protected function execute(InputInterface $input, OutputInterface $output) : int
+    final protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Command/Input/Argument.php
+++ b/src/Command/Input/Argument.php
@@ -12,7 +12,7 @@ use UnexpectedValueException;
  */
 interface Argument
 {
-    public static function name() : string;
+    public static function name(): string;
 
     /**
      * @return mixed
@@ -23,9 +23,9 @@ interface Argument
      */
     public static function value(InputInterface $input);
 
-    public function description() : string;
+    public function description(): string;
 
-    public function mode() : ArgumentMode;
+    public function mode(): ArgumentMode;
 
-    public function default() : ?string;
+    public function default(): ?string;
 }

--- a/src/Command/Input/BrowserPathOption.php
+++ b/src/Command/Input/BrowserPathOption.php
@@ -7,6 +7,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Command\Input;
 use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use function is_string;
 
 /**
@@ -25,34 +26,32 @@ final class BrowserPathOption extends InputOption implements Option
         );
     }
 
-    public static function name() : string
+    public static function name(): string
     {
         return 'browser-path';
     }
 
-    public function shortcut() : ?string
+    public function shortcut(): ?string
     {
         return null;
     }
 
-    public function mode() : OptionMode
+    public function mode(): OptionMode
     {
         return OptionMode::REQUIRED();
     }
 
-    public function description() : string
+    public function description(): string
     {
         return 'Path to the browser if it\'s not installed in the default location';
     }
 
-    public function default() : ?string
+    public function default(): ?string
     {
         return null;
     }
 
     /**
-     * @return string|null
-     *
      * @inheritDoc
      */
     public static function value(InputInterface $input)

--- a/src/Command/Input/InstallPathArgument.php
+++ b/src/Command/Input/InstallPathArgument.php
@@ -7,6 +7,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Command\Input;
 use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+
 use function is_string;
 
 /**
@@ -24,29 +25,27 @@ final class InstallPathArgument extends InputArgument implements Argument
         );
     }
 
-    public static function name() : string
+    public static function name(): string
     {
         return 'install-path';
     }
 
-    public function mode() : ArgumentMode
+    public function mode(): ArgumentMode
     {
         return ArgumentMode::OPTIONAL();
     }
 
-    public function description() : string
+    public function description(): string
     {
         return 'Location where the driver will be installed';
     }
 
-    public function default() : ?string
+    public function default(): ?string
     {
         return '.';
     }
 
     /**
-     * @return string
-     *
      * @inheritDoc
      */
     public static function value(InputInterface $input)

--- a/src/Command/Input/OperatingSystemOption.php
+++ b/src/Command/Input/OperatingSystemOption.php
@@ -10,10 +10,12 @@ use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use UnexpectedValueException;
-use const PHP_OS_FAMILY;
+
 use function implode;
 use function is_string;
 use function Safe\sprintf;
+
+use const PHP_OS_FAMILY;
 
 /**
  * @implements Option<OperatingSystem>
@@ -31,22 +33,22 @@ final class OperatingSystemOption extends InputOption implements Option
         );
     }
 
-    public static function name() : string
+    public static function name(): string
     {
         return 'os';
     }
 
-    public function shortcut() : ?string
+    public function shortcut(): ?string
     {
         return null;
     }
 
-    public function mode() : OptionMode
+    public function mode(): OptionMode
     {
         return OptionMode::REQUIRED();
     }
 
-    public function description() : string
+    public function description(): string
     {
         return sprintf(
             'Operating system for which to install the driver (%s)',
@@ -54,17 +56,12 @@ final class OperatingSystemOption extends InputOption implements Option
         );
     }
 
-    public function default() : ?string
+    public function default(): ?string
     {
-        /**
-         * @psalm-suppress MixedArgument
-         */
         return OperatingSystem::fromFamily(new Family(PHP_OS_FAMILY))->getValue();
     }
 
     /**
-     * @return OperatingSystem
-     *
      * @inheritDoc
      */
     public static function value(InputInterface $input)

--- a/src/Command/Input/Option.php
+++ b/src/Command/Input/Option.php
@@ -12,7 +12,7 @@ use UnexpectedValueException;
  */
 interface Option
 {
-    public static function name() : string;
+    public static function name(): string;
 
     /**
      * @return mixed
@@ -23,11 +23,11 @@ interface Option
      */
     public static function value(InputInterface $input);
 
-    public function shortcut() : ?string;
+    public function shortcut(): ?string;
 
-    public function description() : string;
+    public function description(): string;
 
-    public function mode() : OptionMode;
+    public function mode(): OptionMode;
 
-    public function default() : ?string;
+    public function default(): ?string;
 }

--- a/src/Command/Input/VersionOption.php
+++ b/src/Command/Input/VersionOption.php
@@ -7,6 +7,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Command\Input;
 use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+
 use function is_string;
 
 /**
@@ -27,14 +28,12 @@ final class VersionOption extends InputOption implements Option
         );
     }
 
-    public static function name() : string
+    public static function name(): string
     {
         return 'driver-version';
     }
 
     /**
-     * @return string
-     *
      * @inheritDoc
      */
     public static function value(InputInterface $input)
@@ -48,22 +47,22 @@ final class VersionOption extends InputOption implements Option
         return $value;
     }
 
-    public function shortcut() : ?string
+    public function shortcut(): ?string
     {
         return null;
     }
 
-    public function mode() : OptionMode
+    public function mode(): OptionMode
     {
         return OptionMode::REQUIRED();
     }
 
-    public function description() : string
+    public function description(): string
     {
         return 'Driver version to install';
     }
 
-    public function default() : ?string
+    public function default(): ?string
     {
         return self::LATEST;
     }

--- a/src/CommandLine/CommandLineEnvironment.php
+++ b/src/CommandLine/CommandLineEnvironment.php
@@ -11,5 +11,5 @@ interface CommandLineEnvironment
     /**
      * @throws RuntimeException If command is not successful.
      */
-    public function getCommandLineSuccessfulOutput(string $command) : string;
+    public function getCommandLineSuccessfulOutput(string $command): string;
 }

--- a/src/CommandLine/ShellCommandLineEnvironment.php
+++ b/src/CommandLine/ShellCommandLineEnvironment.php
@@ -7,11 +7,12 @@ namespace DBrekelmans\BrowserDriverInstaller\CommandLine;
 use RuntimeException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+
 use function Safe\sprintf;
 
 class ShellCommandLineEnvironment implements CommandLineEnvironment
 {
-    public function getCommandLineSuccessfulOutput(string $command) : string
+    public function getCommandLineSuccessfulOutput(string $command): string
     {
         $process = Process::fromShellCommandline($command);
         $process->run();

--- a/src/Driver/ChromeDriver/Command.php
+++ b/src/Driver/ChromeDriver/Command.php
@@ -9,7 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
 
 final class Command extends DriverCommand
 {
-    protected static function driverName() : DriverName
+    protected static function driverName(): DriverName
     {
         return DriverName::CHROME();
     }

--- a/src/Driver/ChromeDriver/Downloader.php
+++ b/src/Driver/ChromeDriver/Downloader.php
@@ -17,13 +17,15 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
-use const DIRECTORY_SEPARATOR;
+
 use function count;
 use function Safe\fclose;
 use function Safe\fopen;
 use function Safe\fwrite;
 use function Safe\sprintf;
 use function sys_get_temp_dir;
+
+use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
@@ -48,7 +50,7 @@ final class Downloader implements DownloaderInterface
         $this->archiveExtractor = $archiveExtractor;
     }
 
-    public function supports(Driver $driver) : bool
+    public function supports(Driver $driver): bool
     {
         return $driver->name()->equals(DriverName::CHROME());
     }
@@ -56,7 +58,7 @@ final class Downloader implements DownloaderInterface
     /**
      * @throws RuntimeException
      */
-    public function download(Driver $driver, string $location) : string
+    public function download(Driver $driver, string $location): string
     {
         try {
             $archive = $this->downloadArchive($driver);
@@ -106,9 +108,9 @@ final class Downloader implements DownloaderInterface
      * @throws FilesystemException
      * @throws IOException
      */
-    private function downloadArchive(Driver $driver) : string
+    private function downloadArchive(Driver $driver): string
     {
-        $temporaryFile = $this->filesystem->tempnam(sys_get_temp_dir(), 'chromedriver') . '.zip';
+        $temporaryFile = $this->filesystem->tempnam(sys_get_temp_dir(), 'chromedriver', '.zip');
 
         $response = $this->httpClient->request(
             'GET',
@@ -138,7 +140,7 @@ final class Downloader implements DownloaderInterface
     /**
      * @throws NotImplemented
      */
-    private function getBinaryName(Driver $driver) : string
+    private function getBinaryName(Driver $driver): string
     {
         $operatingSystem = $driver->operatingSystem();
 
@@ -163,7 +165,7 @@ final class Downloader implements DownloaderInterface
      * @throws RuntimeException
      * @throws IOException
      */
-    private function extractArchive(string $archive) : string
+    private function extractArchive(string $archive): string
     {
         $unzipLocation  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'chromedriver';
         $extractedFiles = $this->archiveExtractor->extract($archive, $unzipLocation);
@@ -183,7 +185,7 @@ final class Downloader implements DownloaderInterface
         return $file;
     }
 
-    private function getFilePath(string $location, OperatingSystem $operatingSystem) : string
+    private function getFilePath(string $location, OperatingSystem $operatingSystem): string
     {
         $filePath = $location . DIRECTORY_SEPARATOR . 'chromedriver';
 

--- a/src/Driver/ChromeDriver/VersionResolver.php
+++ b/src/Driver/ChromeDriver/VersionResolver.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
+
 use function Safe\sprintf;
 
 final class VersionResolver implements VersionResolverInterface
@@ -30,7 +31,7 @@ final class VersionResolver implements VersionResolverInterface
         $this->httpClient = $httpClient;
     }
 
-    public function fromBrowser(Browser $browser) : Version
+    public function fromBrowser(Browser $browser): Version
     {
         if (! $this->supports($browser)) {
             throw new Unsupported(sprintf('%s is not supported.', $browser->name()->getValue()));
@@ -38,7 +39,8 @@ final class VersionResolver implements VersionResolverInterface
 
         try {
             $content = $this->httpClient->request('GET', $this->getBrowserVersionEndpoint($browser))->getContent();
-        } catch (ClientExceptionInterface
+        } catch (
+            ClientExceptionInterface
                 | RedirectionExceptionInterface
                 | ServerExceptionInterface
                 | TransportExceptionInterface
@@ -62,7 +64,7 @@ final class VersionResolver implements VersionResolverInterface
         }
     }
 
-    public function latest() : Version
+    public function latest(): Version
     {
         $response      = $this->httpClient->request('GET', self::VERSION_ENDPOINT);
         $versionString = $response->getContent();
@@ -70,7 +72,7 @@ final class VersionResolver implements VersionResolverInterface
         return Version::fromString($versionString);
     }
 
-    public function supports(Browser $browser) : bool
+    public function supports(Browser $browser): bool
     {
         return $browser->name()->equals(BrowserName::GOOGLE_CHROME()) || $browser->name()->equals(BrowserName::CHROMIUM());
     }
@@ -78,7 +80,7 @@ final class VersionResolver implements VersionResolverInterface
     /**
      * In case of handling with Chrome from Dev or Canary channel we will then take beta ChromeDriver
      */
-    private function getBrowserVersionEndpoint(Browser $browser) : string
+    private function getBrowserVersionEndpoint(Browser $browser): string
     {
         $versionEndpoint = sprintf('%s_%s', self::VERSION_ENDPOINT, $browser->version()->toString());
 

--- a/src/Driver/Downloader.php
+++ b/src/Driver/Downloader.php
@@ -11,7 +11,7 @@ interface Downloader
     /**
      * @throws RuntimeException
      */
-    public function download(Driver $driver, string $location) : string;
+    public function download(Driver $driver, string $location): string;
 
-    public function supports(Driver $driver) : bool;
+    public function supports(Driver $driver): bool;
 }

--- a/src/Driver/DownloaderFactory.php
+++ b/src/Driver/DownloaderFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Driver;
 
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+
 use function get_class;
 use function Safe\sprintf;
 
@@ -16,7 +17,7 @@ final class DownloaderFactory
      */
     private $downloaders = [];
 
-    public function createFromDriver(Driver $driver) : Downloader
+    public function createFromDriver(Driver $driver): Downloader
     {
         foreach ($this->downloaders as $downloader) {
             if ($downloader->supports($driver)) {
@@ -27,7 +28,7 @@ final class DownloaderFactory
         throw NotImplemented::feature(sprintf('Downloader for %s', $driver->name()->getValue()));
     }
 
-    public function register(Downloader $downloader) : void
+    public function register(Downloader $downloader): void
     {
         $this->downloaders[get_class($downloader)] = $downloader;
     }

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -25,17 +25,17 @@ final class Driver
         $this->operatingSystem = $operatingSystem;
     }
 
-    public function name() : DriverName
+    public function name(): DriverName
     {
         return $this->name;
     }
 
-    public function version() : Version
+    public function version(): Version
     {
         return $this->version;
     }
 
-    public function operatingSystem() : OperatingSystem
+    public function operatingSystem(): OperatingSystem
     {
         return $this->operatingSystem;
     }

--- a/src/Driver/DriverFactory.php
+++ b/src/Driver/DriverFactory.php
@@ -7,6 +7,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver;
 use DBrekelmans\BrowserDriverInstaller\Browser\Browser;
 use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+
 use function Safe\sprintf;
 
 final class DriverFactory
@@ -19,7 +20,7 @@ final class DriverFactory
         $this->versionResolverFactory = $versionResolverFactory;
     }
 
-    public function createFromBrowser(Browser $browser) : Driver
+    public function createFromBrowser(Browser $browser): Driver
     {
         $versionResolver = $this->versionResolverFactory->createFromBrowser($browser);
         $version         = $versionResolver->fromBrowser($browser);
@@ -32,7 +33,7 @@ final class DriverFactory
     /**
      * @throws NotImplemented
      */
-    private function getDriverNameForBrowser(Browser $browser) : DriverName
+    private function getDriverNameForBrowser(Browser $browser): DriverName
     {
         $browserName = $browser->name();
 

--- a/src/Driver/GeckoDriver/Command.php
+++ b/src/Driver/GeckoDriver/Command.php
@@ -9,7 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
 
 final class Command extends DriverCommand
 {
-    protected static function driverName() : DriverName
+    protected static function driverName(): DriverName
     {
         return DriverName::GECKO();
     }

--- a/src/Driver/GeckoDriver/Downloader.php
+++ b/src/Driver/GeckoDriver/Downloader.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use const DIRECTORY_SEPARATOR;
+
 use function basename;
 use function dirname;
 use function Safe\fclose;
@@ -25,6 +25,8 @@ use function Safe\fwrite;
 use function Safe\sprintf;
 use function strpos;
 use function sys_get_temp_dir;
+
+use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
@@ -49,7 +51,7 @@ final class Downloader implements DownloaderInterface
         $this->archiveExtractor = $archiveExtractor;
     }
 
-    public function download(Driver $driver, string $location) : string
+    public function download(Driver $driver, string $location): string
     {
         try {
             $archive = $this->downloadArchive($driver);
@@ -82,7 +84,7 @@ final class Downloader implements DownloaderInterface
         return $filePath;
     }
 
-    public function supports(Driver $driver) : bool
+    public function supports(Driver $driver): bool
     {
         return $driver->name()->equals(DriverName::GECKO());
     }
@@ -91,9 +93,9 @@ final class Downloader implements DownloaderInterface
      * @throws FilesystemException
      * @throws TransportExceptionInterface
      */
-    private function downloadArchive(Driver $driver) : string
+    private function downloadArchive(Driver $driver): string
     {
-        $temporaryFile = $this->filesystem->tempnam(sys_get_temp_dir(), 'geckodriver') . $this->getArchiveExtension($driver);
+        $temporaryFile = $this->filesystem->tempnam(sys_get_temp_dir(), 'geckodriver', $this->getArchiveExtension($driver));
 
         $response = $this->httpClient->request('GET', $this->getDownloadPath($driver));
 
@@ -115,7 +117,7 @@ final class Downloader implements DownloaderInterface
     /**
      * @throws NotImplemented
      */
-    private function getDownloadPath(Driver $driver) : string
+    private function getDownloadPath(Driver $driver): string
     {
         return self::DOWNLOAD_BASE_PATH . sprintf(
             'v%s/geckodriver-v%s-%s%s',
@@ -129,7 +131,7 @@ final class Downloader implements DownloaderInterface
     /**
      * @throws NotImplemented
      */
-    private function getOsForDownloadPath(Driver $driver) : string
+    private function getOsForDownloadPath(Driver $driver): string
     {
         $operatingSystem = $driver->operatingSystem();
 
@@ -150,7 +152,7 @@ final class Downloader implements DownloaderInterface
         );
     }
 
-    private function extractArchive(string $archive) : string
+    private function extractArchive(string $archive): string
     {
         $extractedFiles = $this->archiveExtractor->extract($archive, dirname($archive));
 
@@ -163,7 +165,7 @@ final class Downloader implements DownloaderInterface
         throw new RuntimeException(sprintf('Archive %s does not contain any geckodriver file', $archive));
     }
 
-    private function getArchiveExtension(Driver $driver) : string
+    private function getArchiveExtension(Driver $driver): string
     {
         if ($driver->operatingSystem()->equals(OperatingSystem::WINDOWS())) {
             return '.zip';

--- a/src/Driver/GeckoDriver/VersionResolver.php
+++ b/src/Driver/GeckoDriver/VersionResolver.php
@@ -11,6 +11,7 @@ use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
 use DBrekelmans\BrowserDriverInstaller\Version;
 use RuntimeException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 use function is_string;
 use function Safe\json_decode;
 use function Safe\krsort;
@@ -40,7 +41,7 @@ final class VersionResolver implements VersionResolverInterface
     /**
      * @see https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
      */
-    public function fromBrowser(Browser $browser) : Version
+    public function fromBrowser(Browser $browser): Version
     {
         $browserMajorVersion = (int) $browser->version()->major();
 
@@ -63,7 +64,7 @@ final class VersionResolver implements VersionResolverInterface
         throw new RuntimeException(sprintf('Could not find a geckodriver version for Firefox %s', $browser->version()->toString()));
     }
 
-    public function latest() : Version
+    public function latest(): Version
     {
         $response = $this->httpClient->request('GET', self::LATEST_VERSION_ENDPOINT);
         /** @var array<mixed> $data */
@@ -75,7 +76,7 @@ final class VersionResolver implements VersionResolverInterface
         return Version::fromString((string) $data['name']);
     }
 
-    public function supports(Browser $browser) : bool
+    public function supports(Browser $browser): bool
     {
         return $browser->name()->equals(BrowserName::FIREFOX());
     }

--- a/src/Driver/VersionResolver.php
+++ b/src/Driver/VersionResolver.php
@@ -15,9 +15,9 @@ interface VersionResolver
      * @throws RuntimeException If the version could not be resolved.
      * @throws NotImplemented If the browser is not yet supported.
      */
-    public function fromBrowser(Browser $browser) : Version;
+    public function fromBrowser(Browser $browser): Version;
 
-    public function latest() : Version;
+    public function latest(): Version;
 
-    public function supports(Browser $browser) : bool;
+    public function supports(Browser $browser): bool;
 }

--- a/src/Driver/VersionResolverFactory.php
+++ b/src/Driver/VersionResolverFactory.php
@@ -6,6 +6,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver;
 
 use DBrekelmans\BrowserDriverInstaller\Browser\Browser;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+
 use function get_class;
 use function Safe\sprintf;
 
@@ -20,7 +21,7 @@ final class VersionResolverFactory
     /**
      * @throws NotImplemented If no version resolver is implemented for browser.
      */
-    public function createFromBrowser(Browser $browser) : VersionResolver
+    public function createFromBrowser(Browser $browser): VersionResolver
     {
         foreach ($this->versionResolvers as $versionResolver) {
             if ($versionResolver->supports($browser)) {
@@ -33,7 +34,7 @@ final class VersionResolverFactory
         );
     }
 
-    public function register(VersionResolver $versionResolver) : void
+    public function register(VersionResolver $versionResolver): void
     {
         $this->versionResolvers[get_class($versionResolver)] = $versionResolver;
     }

--- a/src/Exception/NotImplemented.php
+++ b/src/Exception/NotImplemented.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Exception;
 
 use LogicException;
+
 use function Safe\sprintf;
 
 /** @internal */
 final class NotImplemented extends LogicException
 {
-    public static function feature(string $feature) : self
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function feature(string $feature): self
     {
         return new self(sprintf('%s is not implemented.', $feature));
     }

--- a/src/Exception/UnexpectedType.php
+++ b/src/Exception/UnexpectedType.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace DBrekelmans\BrowserDriverInstaller\Exception;
 
+use Throwable;
 use UnexpectedValueException;
+
 use function get_debug_type;
 use function Safe\sprintf;
 
 final class UnexpectedType extends UnexpectedValueException
 {
+    private function __construct(string $message, int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
     /**
      * @param mixed $actual
      */
-    public static function expected(string $expected, $actual) : self
+    public static function expected(string $expected, $actual): self
     {
         return new self(sprintf('Unexpected type %s. Expected %s.', get_debug_type($actual), $expected));
     }

--- a/src/OperatingSystem/OperatingSystem.php
+++ b/src/OperatingSystem/OperatingSystem.php
@@ -19,7 +19,7 @@ final class OperatingSystem extends Enum
     public const MACOS   = 'macos';
     public const LINUX   = 'linux';
 
-    public static function fromFamily(Family $family) : self
+    public static function fromFamily(Family $family): self
     {
         if ($family->equals(Family::WINDOWS())) {
             return self::WINDOWS();

--- a/src/Version.php
+++ b/src/Version.php
@@ -6,6 +6,7 @@ namespace DBrekelmans\BrowserDriverInstaller;
 
 use InvalidArgumentException;
 use Safe\Exceptions\PcreException;
+
 use function implode;
 use function Safe\preg_match;
 use function Safe\sprintf;
@@ -37,14 +38,15 @@ final class Version
     /**
      * @throws InvalidArgumentException
      */
-    public static function fromString(string $versionString) : self
+    public static function fromString(string $versionString): self
     {
         try {
-            if (preg_match(
-                "/(?'major'\d+)\.(?'minor'\d+)(\.(?'patch'\d+))?(\.(?'build'\d+))?/",
-                $versionString,
-                $matches
-            ) === 0
+            if (
+                preg_match(
+                    "/(?'major'\d+)\.(?'minor'\d+)(\.(?'patch'\d+))?(\.(?'build'\d+))?/",
+                    $versionString,
+                    $matches
+                ) === 0
             ) {
                 throw new InvalidArgumentException(
                     sprintf('Could not parse version string "%s".', $versionString)
@@ -72,27 +74,27 @@ final class Version
         }
     }
 
-    public function major() : string
+    public function major(): string
     {
         return $this->major;
     }
 
-    public function minor() : string
+    public function minor(): string
     {
         return $this->minor;
     }
 
-    public function patch() : ?string
+    public function patch(): ?string
     {
         return $this->patch;
     }
 
-    public function build() : ?string
+    public function build(): ?string
     {
         return $this->build;
     }
 
-    public function toBuildString() : string
+    public function toBuildString(): string
     {
         $versionString = $this->toString();
 
@@ -103,7 +105,7 @@ final class Version
         return $versionString;
     }
 
-    public function toString() : string
+    public function toString(): string
     {
         $versionString = implode(self::DELIMITER, [$this->major, $this->minor]);
 

--- a/tests/Browser/BrowserFactoryTest.php
+++ b/tests/Browser/BrowserFactoryTest.php
@@ -17,14 +17,14 @@ use PHPUnit\Framework\TestCase;
 
 final class BrowserFactoryTest extends TestCase
 {
-    private static function assertBrowser(Browser $expected, Browser $actual) : void
+    private static function assertBrowser(Browser $expected, Browser $actual): void
     {
         self::assertTrue($expected->name()->equals($actual->name()));
         self::assertTrue($expected->operatingSystem()->equals($actual->operatingSystem()));
         self::assertSame($expected->version()->toBuildString(), $actual->version()->toBuildString());
     }
 
-    public function testCreateFromNameOperatingSystem() : void
+    public function testCreateFromNameOperatingSystem(): void
     {
         $pathResolverFactory    = new PathResolverFactory();
         $versionResolverFactory = new VersionResolverFactory();
@@ -35,13 +35,13 @@ final class BrowserFactoryTest extends TestCase
         $version         = Version::fromString('1.0.0');
         $operatingSystem = OperatingSystem::LINUX();
 
-        $versionResolver = $this->createMock(VersionResolver::class);
+        $versionResolver = $this->createStub(VersionResolver::class);
         $versionResolver->method('supports')->willReturn(true);
         $versionResolver->method('from')->willReturn($version);
 
         $versionResolverFactory->register($versionResolver);
 
-        $pathResolver = $this->createMock(PathResolver::class);
+        $pathResolver = $this->createStub(PathResolver::class);
         $pathResolver->method('supports')->willReturn(true);
         $pathResolver->method('from')->willReturn('');
 
@@ -53,7 +53,7 @@ final class BrowserFactoryTest extends TestCase
         );
     }
 
-    public function testCreateFromNameOperatingSystemAndPath() : void
+    public function testCreateFromNameOperatingSystemAndPath(): void
     {
         $versionResolverFactory = new VersionResolverFactory();
 
@@ -63,7 +63,7 @@ final class BrowserFactoryTest extends TestCase
         $version         = Version::fromString('1.0.0');
         $operatingSystem = OperatingSystem::LINUX();
 
-        $versionResolver = $this->createMock(VersionResolver::class);
+        $versionResolver = $this->createStub(VersionResolver::class);
         $versionResolver->method('supports')->willReturn(true);
         $versionResolver->method('from')->willReturn($version);
 

--- a/tests/Browser/Chromium/PathResolverTest.php
+++ b/tests/Browser/Chromium/PathResolverTest.php
@@ -14,7 +14,7 @@ final class PathResolverTest extends TestCase
     /** @var PathResolver */
     private $pathResolver;
 
-    public function testFromKnownOs() : void
+    public function testFromKnownOs(): void
     {
         self::assertSame('chromium', $this->pathResolver->from(OperatingSystem::LINUX()));
         self::assertSame('/Applications/Chromium.app', $this->pathResolver->from(OperatingSystem::MACOS()));
@@ -24,17 +24,17 @@ final class PathResolverTest extends TestCase
         );
     }
 
-    public function testSupportChromium() : void
+    public function testSupportChromium(): void
     {
         self::assertTrue($this->pathResolver->supports(BrowserName::CHROMIUM()));
     }
 
-    public function testDoesNotSupportFirefox() : void
+    public function testDoesNotSupportFirefox(): void
     {
         self::assertFalse($this->pathResolver->supports(BrowserName::FIREFOX()));
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->pathResolver = new PathResolver();
     }

--- a/tests/Browser/Chromium/VersionResolverTest.php
+++ b/tests/Browser/Chromium/VersionResolverTest.php
@@ -20,17 +20,17 @@ class VersionResolverTest extends TestCase
     /** @var MockObject&CommandLineEnvironment */
     private $commandLineEnvMock;
 
-    public function testSupportChromium() : void
+    public function testSupportChromium(): void
     {
         self::assertTrue($this->versionResolver->supports(BrowserName::CHROMIUM()));
     }
 
-    public function testDoesNotSupportFirefox() : void
+    public function testDoesNotSupportFirefox(): void
     {
         self::assertFalse($this->versionResolver->supports(BrowserName::FIREFOX()));
     }
 
-    public function testFromMac() : void
+    public function testFromMac(): void
     {
         $this->mockCommandLineCommandOutput(
             '/Applications/Chromium.app/Contents/MacOS/Chromium --version',
@@ -43,7 +43,7 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromLinux() : void
+    public function testFromLinux(): void
     {
         $this->mockCommandLineCommandOutput('chromium --version', 'Chromium 88.0.4299.0');
 
@@ -53,7 +53,7 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromWindows() : void
+    public function testFromWindows(): void
     {
         $this->mockCommandLineCommandOutput(
             'reg query HKLM\Software\Google\Update\Clients\{8A69D345-D564-463c-AFF1-A69D9E530F96} /v pv /reg:32 2> NUL',
@@ -70,13 +70,13 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->commandLineEnvMock = $this->createMock(CommandLineEnvironment::class);
         $this->versionResolver    = new VersionResolver($this->commandLineEnvMock);
     }
 
-    private function mockCommandLineCommandOutput(string $command, string $output) : void
+    private function mockCommandLineCommandOutput(string $command, string $output): void
     {
         $this->commandLineEnvMock
             ->method('getCommandLineSuccessfulOutput')

--- a/tests/Browser/Firefox/PathResolverTest.php
+++ b/tests/Browser/Firefox/PathResolverTest.php
@@ -14,7 +14,7 @@ final class PathResolverTest extends TestCase
     /** @var PathResolver */
     private $pathResolver;
 
-    public function testFromKnownOs() : void
+    public function testFromKnownOs(): void
     {
         self::assertSame('firefox', $this->pathResolver->from(OperatingSystem::LINUX()));
         self::assertSame('/Applications/Firefox.app', $this->pathResolver->from(OperatingSystem::MACOS()));
@@ -24,17 +24,17 @@ final class PathResolverTest extends TestCase
         );
     }
 
-    public function testDoesNotSupportChrome() : void
+    public function testDoesNotSupportChrome(): void
     {
         self::assertFalse($this->pathResolver->supports(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testSupportsFirefox() : void
+    public function testSupportsFirefox(): void
     {
         self::assertTrue($this->pathResolver->supports(BrowserName::FIREFOX()));
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->pathResolver = new PathResolver();
     }

--- a/tests/Browser/Firefox/VersionResolverTest.php
+++ b/tests/Browser/Firefox/VersionResolverTest.php
@@ -20,17 +20,17 @@ final class VersionResolverTest extends TestCase
     /** @var MockObject&CommandLineEnvironment */
     private $commandLineEnvMock;
 
-    public function testDoesNotSupportChrome() : void
+    public function testDoesNotSupportChrome(): void
     {
         self::assertFalse($this->versionResolver->supports(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testSupportsFirefox() : void
+    public function testSupportsFirefox(): void
     {
         self::assertTrue($this->versionResolver->supports(BrowserName::FIREFOX()));
     }
 
-    public function testFromLinux() : void
+    public function testFromLinux(): void
     {
         $this->mockCommandLineCommandOutput('firefox --version', 'Mozilla Firefox 83.0');
 
@@ -40,7 +40,7 @@ final class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromMac() : void
+    public function testFromMac(): void
     {
         $this->mockCommandLineCommandOutput(
             '/Applications/Firefox.app/Contents/MacOS/firefox --version',
@@ -53,7 +53,7 @@ final class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromWindows() : void
+    public function testFromWindows(): void
     {
         $this->mockCommandLineCommandOutput(
             '"C:\\Program Files\\Mozilla Firefox\\firefox" --version | more',
@@ -66,13 +66,13 @@ final class VersionResolverTest extends TestCase
         );
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->commandLineEnvMock = $this->createMock(CommandLineEnvironment::class);
         $this->versionResolver    = new VersionResolver($this->commandLineEnvMock);
     }
 
-    private function mockCommandLineCommandOutput(string $command, string $output) : void
+    private function mockCommandLineCommandOutput(string $command, string $output): void
     {
         $this->commandLineEnvMock
             ->method('getCommandLineSuccessfulOutput')

--- a/tests/Browser/GoogleChrome/PathResolverTest.php
+++ b/tests/Browser/GoogleChrome/PathResolverTest.php
@@ -14,7 +14,7 @@ final class PathResolverTest extends TestCase
     /** @var PathResolver */
     private $pathResolver;
 
-    public function testFromKnownOs() : void
+    public function testFromKnownOs(): void
     {
         self::assertSame('google-chrome', $this->pathResolver->from(OperatingSystem::LINUX()));
         self::assertSame('/Applications/Google\ Chrome.app', $this->pathResolver->from(OperatingSystem::MACOS()));
@@ -24,17 +24,17 @@ final class PathResolverTest extends TestCase
         );
     }
 
-    public function testSupportChrome() : void
+    public function testSupportChrome(): void
     {
         self::assertTrue($this->pathResolver->supports(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testDoesNotSupportFirefox() : void
+    public function testDoesNotSupportFirefox(): void
     {
         self::assertFalse($this->pathResolver->supports(BrowserName::FIREFOX()));
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->pathResolver = new PathResolver();
     }

--- a/tests/Browser/GoogleChrome/VersionResolverTest.php
+++ b/tests/Browser/GoogleChrome/VersionResolverTest.php
@@ -20,17 +20,17 @@ class VersionResolverTest extends TestCase
     /** @var MockObject&CommandLineEnvironment */
     private $commandLineEnvMock;
 
-    public function testSupportChrome() : void
+    public function testSupportChrome(): void
     {
         self::assertTrue($this->versionResolver->supports(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testDoesNotSupportFirefox() : void
+    public function testDoesNotSupportFirefox(): void
     {
         self::assertFalse($this->versionResolver->supports(BrowserName::FIREFOX()));
     }
 
-    public function testFromLinux() : void
+    public function testFromLinux(): void
     {
         $this->mockCommandLineCommandOutput('google-chrome --version', 'Google Chrome 86.0.4240.80');
 
@@ -40,7 +40,7 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromMac() : void
+    public function testFromMac(): void
     {
         $this->mockCommandLineCommandOutput(
             '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
@@ -53,7 +53,7 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    public function testFromWindows() : void
+    public function testFromWindows(): void
     {
         $this->mockCommandLineCommandOutput(
             'reg query HKLM\Software\Google\Update\Clients\{8A69D345-D564-463c-AFF1-A69D9E530F96} /v pv /reg:32 2> NUL',
@@ -70,13 +70,13 @@ class VersionResolverTest extends TestCase
         );
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->commandLineEnvMock = $this->createMock(CommandLineEnvironment::class);
         $this->versionResolver    = new VersionResolver($this->commandLineEnvMock);
     }
 
-    private function mockCommandLineCommandOutput(string $command, string $output) : void
+    private function mockCommandLineCommandOutput(string $command, string $output): void
     {
         $this->commandLineEnvMock
             ->method('getCommandLineSuccessfulOutput')

--- a/tests/Browser/PathResolverFactoryTest.php
+++ b/tests/Browser/PathResolverFactoryTest.php
@@ -9,14 +9,13 @@ use DBrekelmans\BrowserDriverInstaller\Browser\PathResolver;
 use DBrekelmans\BrowserDriverInstaller\Browser\PathResolverFactory;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\Tests\UniqueClassName;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class PathResolverFactoryTest extends TestCase
 {
     use UniqueClassName;
 
-    public function testNoPathResolverImplemented() : void
+    public function testNoPathResolverImplemented(): void
     {
         $factory = new PathResolverFactory();
 
@@ -24,9 +23,9 @@ final class PathResolverFactoryTest extends TestCase
         $factory->createFromName(BrowserName::GOOGLE_CHROME());
     }
 
-    public function testRegisteredPathResolverIsReturned() : void
+    public function testRegisteredPathResolverIsReturned(): void
     {
-        $pathResolver = $this->createMock(PathResolver::class);
+        $pathResolver = $this->createStub(PathResolver::class);
         $pathResolver->method('supports')->willReturn(true);
 
         $factory = new PathResolverFactory();
@@ -35,21 +34,18 @@ final class PathResolverFactoryTest extends TestCase
         self::assertSame($pathResolver, $factory->createFromName(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testSupportedPathResolverIsReturned() : void
+    public function testSupportedPathResolverIsReturned(): void
     {
-        /** @var PathResolver&MockObject $pathResolverA */
         $pathResolverA = $this->getMockBuilder(PathResolver::class)
             ->setMockClassName(self::uniqueClassName(PathResolver::class))
             ->getMock();
         $pathResolverA->method('supports')->willReturn(false);
 
-        /** @var PathResolver&MockObject $pathResolverB */
         $pathResolverB = $this->getMockBuilder(PathResolver::class)
             ->setMockClassName(self::uniqueClassName(PathResolver::class))
             ->getMock();
         $pathResolverB->method('supports')->willReturn(true);
 
-        /** @var PathResolver&MockObject $pathResolverC */
         $pathResolverC = $this->getMockBuilder(PathResolver::class)
             ->setMockClassName(self::uniqueClassName(PathResolver::class))
             ->getMock();
@@ -63,15 +59,13 @@ final class PathResolverFactoryTest extends TestCase
         self::assertSame($pathResolverB, $factory->createFromName(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testFirstSupportedPathResolverIsReturned() : void
+    public function testFirstSupportedPathResolverIsReturned(): void
     {
-        /** @var PathResolver&MockObject $pathResolverA */
         $pathResolverA = $this->getMockBuilder(PathResolver::class)
             ->setMockClassName(self::uniqueClassName(PathResolver::class))
             ->getMock();
         $pathResolverA->method('supports')->willReturn(true);
 
-        /** @var PathResolver&MockObject $pathResolverB */
         $pathResolverB = $this->getMockBuilder(PathResolver::class)
             ->setMockClassName(self::uniqueClassName(PathResolver::class))
             ->getMock();

--- a/tests/Browser/VersionResolverFactoryTest.php
+++ b/tests/Browser/VersionResolverFactoryTest.php
@@ -9,14 +9,13 @@ use DBrekelmans\BrowserDriverInstaller\Browser\VersionResolver;
 use DBrekelmans\BrowserDriverInstaller\Browser\VersionResolverFactory;
 use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\Tests\UniqueClassName;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class VersionResolverFactoryTest extends TestCase
 {
     use UniqueClassName;
 
-    public function testNoVersionResolverImplemented() : void
+    public function testNoVersionResolverImplemented(): void
     {
         $factory = new VersionResolverFactory();
 
@@ -24,9 +23,9 @@ final class VersionResolverFactoryTest extends TestCase
         $factory->createFromName(BrowserName::GOOGLE_CHROME());
     }
 
-    public function testRegisteredVersionResolverIsReturned() : void
+    public function testRegisteredVersionResolverIsReturned(): void
     {
-        $versionResolver = $this->createMock(VersionResolver::class);
+        $versionResolver = $this->createStub(VersionResolver::class);
         $versionResolver->method('supports')->willReturn(true);
 
         $factory = new VersionResolverFactory();
@@ -35,21 +34,18 @@ final class VersionResolverFactoryTest extends TestCase
         self::assertSame($versionResolver, $factory->createFromName(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testSupportedVersionResolverIsReturned() : void
+    public function testSupportedVersionResolverIsReturned(): void
     {
-        /** @var VersionResolver&MockObject $versionResolverA */
         $versionResolverA = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverA->method('supports')->willReturn(false);
 
-        /** @var VersionResolver&MockObject $versionResolverB */
         $versionResolverB = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverB->method('supports')->willReturn(true);
 
-        /** @var VersionResolver&MockObject $versionResolverC */
         $versionResolverC = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
@@ -63,15 +59,13 @@ final class VersionResolverFactoryTest extends TestCase
         self::assertSame($versionResolverB, $factory->createFromName(BrowserName::GOOGLE_CHROME()));
     }
 
-    public function testFirstSupportedVersionResolverIsReturned() : void
+    public function testFirstSupportedVersionResolverIsReturned(): void
     {
-        /** @var VersionResolver&MockObject $versionResolverA */
         $versionResolverA = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverA->method('supports')->willReturn(true);
 
-        /** @var VersionResolver&MockObject $versionResolverB */
         $versionResolverB = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -12,10 +12,13 @@ use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Version;
 use PHPStan\Testing\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use const DIRECTORY_SEPARATOR;
+
 use function sys_get_temp_dir;
+
+use const DIRECTORY_SEPARATOR;
 
 class DownloaderTest extends TestCase
 {
@@ -25,27 +28,27 @@ class DownloaderTest extends TestCase
     /** @var Driver */
     private $chromeDriverMac;
 
-    /** @var MockObject&Filesystem */
+    /** @var Stub&Filesystem */
     private $filesystem;
 
-    /** @var MockObject&Extractor */
+    /** @var Stub&Extractor */
     private $archiveExtractor;
 
     /** @var MockObject&HttpClientInterface */
     private $httpClient;
 
-    public function testSupportChrome() : void
+    public function testSupportChrome(): void
     {
         self::assertTrue($this->downloader->supports($this->chromeDriverMac));
     }
 
-    public function testDoesNotSupportGecko() : void
+    public function testDoesNotSupportGecko(): void
     {
         $geckoDriver = new Driver(DriverName::GECKO(), Version::fromString('0.27.0'), OperatingSystem::MACOS());
         self::assertFalse($this->downloader->supports($geckoDriver));
     }
 
-    public function testDownloadMac() : void
+    public function testDownloadMac(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload();
 
@@ -59,7 +62,7 @@ class DownloaderTest extends TestCase
         self::assertEquals('./chromedriver', $filePath);
     }
 
-    public function testDownloadLinux() : void
+    public function testDownloadLinux(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload();
 
@@ -74,7 +77,7 @@ class DownloaderTest extends TestCase
         self::assertEquals('./chromedriver', $filePath);
     }
 
-    public function testDownloadWindows() : void
+    public function testDownloadWindows(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload();
 
@@ -89,17 +92,17 @@ class DownloaderTest extends TestCase
         self::assertEquals('./chromedriver.exe', $filePath);
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
-        $this->filesystem       = $this->createMock(Filesystem::class);
+        $this->filesystem       = $this->createStub(Filesystem::class);
         $this->httpClient       = $this->createMock(HttpClientInterface::class);
-        $this->archiveExtractor = $this->createMock(Extractor::class);
+        $this->archiveExtractor = $this->createStub(Extractor::class);
         $this->downloader       = new Downloader($this->filesystem, $this->httpClient, $this->archiveExtractor);
 
         $this->chromeDriverMac = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::MACOS());
     }
 
-    private function mockFsAndArchiveExtractorForSuccessfulDownload() : void
+    private function mockFsAndArchiveExtractorForSuccessfulDownload(): void
     {
         $this->filesystem
             ->method('tempnam')

--- a/tests/Driver/ChromeDriver/VersionResolverTest.php
+++ b/tests/Driver/ChromeDriver/VersionResolverTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use UnexpectedValueException;
+
 use function in_array;
 
 class VersionResolverTest extends TestCase
@@ -30,33 +31,33 @@ class VersionResolverTest extends TestCase
     /** @var Browser */
     private $firefox;
 
-    public function testSupportChrome() : void
+    public function testSupportChrome(): void
     {
         self::assertTrue($this->versionResolver->supports($this->chrome));
     }
 
-    public function testSupportChromium() : void
+    public function testSupportChromium(): void
     {
         self::assertTrue($this->versionResolver->supports($this->chromium));
     }
 
-    public function testDoesNotSupportFirefox() : void
+    public function testDoesNotSupportFirefox(): void
     {
         self::assertFalse($this->versionResolver->supports($this->firefox));
     }
 
-    public function testFromThrowsExceptionForFirefox() : void
+    public function testFromThrowsExceptionForFirefox(): void
     {
         $this->expectException(Unsupported::class);
         $this->versionResolver->fromBrowser($this->firefox);
     }
 
-    public function testFromGetVersionForChrome() : void
+    public function testFromGetVersionForChrome(): void
     {
         self::assertEquals(Version::fromString('86.0.4240.22'), $this->versionResolver->fromBrowser($this->chrome));
     }
 
-    public function testFromExceptionIfCanNotParseVersionReceived() : void
+    public function testFromExceptionIfCanNotParseVersionReceived(): void
     {
         $this->expectException(UnexpectedValueException::class);
         $wrongChrome = new Browser(BrowserName::GOOGLE_CHROME(), Version::fromString('1.0.0.0'), OperatingSystem::MACOS());
@@ -64,22 +65,22 @@ class VersionResolverTest extends TestCase
         $this->versionResolver->fromBrowser($wrongChrome);
     }
 
-    public function testFromGetBetaVersionForDevChrome() : void
+    public function testFromGetBetaVersionForDevChrome(): void
     {
         $devChrome = new Browser(BrowserName::GOOGLE_CHROME(), Version::fromString('88.0.4302.0'), OperatingSystem::MACOS());
 
         self::assertEquals(Version::fromString('87.0.4280.20'), $this->versionResolver->fromBrowser($devChrome));
     }
 
-    public function testLatest() : void
+    public function testLatest(): void
     {
         self::assertEquals(Version::fromString('86.0.4240.22'), $this->versionResolver->latest());
     }
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $httpClientMock        = new MockHttpClient(
-            static function (string $method, string $url) : MockResponse {
+            static function (string $method, string $url): MockResponse {
                 $urlsGiving86Version = [
                     'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_86.0.4240',
                     'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_86',

--- a/tests/Driver/DownloaderFactoryTest.php
+++ b/tests/Driver/DownloaderFactoryTest.php
@@ -12,14 +12,13 @@ use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Tests\UniqueClassName;
 use DBrekelmans\BrowserDriverInstaller\Version;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class DownloaderFactoryTest extends TestCase
 {
     use UniqueClassName;
 
-    public function testNoDownloaderImplemented() : void
+    public function testNoDownloaderImplemented(): void
     {
         $factory = new DownloaderFactory();
 
@@ -29,9 +28,9 @@ final class DownloaderFactoryTest extends TestCase
         );
     }
 
-    public function testRegisteredDownloaderIsReturned() : void
+    public function testRegisteredDownloaderIsReturned(): void
     {
-        $downloader = $this->createMock(Downloader::class);
+        $downloader = $this->createStub(Downloader::class);
         $downloader->method('supports')->willReturn(true);
 
         $factory = new DownloaderFactory();
@@ -45,21 +44,18 @@ final class DownloaderFactoryTest extends TestCase
         );
     }
 
-    public function testSupportedDownloaderIsReturned() : void
+    public function testSupportedDownloaderIsReturned(): void
     {
-        /** @var Downloader&MockObject $downloaderA */
         $downloaderA = $this->getMockBuilder(Downloader::class)
             ->setMockClassName(self::uniqueClassName(Downloader::class))
             ->getMock();
         $downloaderA->method('supports')->willReturn(false);
 
-        /** @var Downloader&MockObject $downloaderB */
         $downloaderB = $this->getMockBuilder(Downloader::class)
             ->setMockClassName(self::uniqueClassName(Downloader::class))
             ->getMock();
         $downloaderB->method('supports')->willReturn(true);
 
-        /** @var Downloader&MockObject $downloaderC */
         $downloaderC = $this->getMockBuilder(Downloader::class)
             ->setMockClassName(self::uniqueClassName(Downloader::class))
             ->getMock();
@@ -78,15 +74,13 @@ final class DownloaderFactoryTest extends TestCase
         );
     }
 
-    public function testFirstSupportedDownloaderIsReturned() : void
+    public function testFirstSupportedDownloaderIsReturned(): void
     {
-        /** @var Downloader&MockObject $downloaderA */
         $downloaderA = $this->getMockBuilder(Downloader::class)
             ->setMockClassName(self::uniqueClassName(Downloader::class))
             ->getMock();
         $downloaderA->method('supports')->willReturn(true);
 
-        /** @var Downloader&MockObject $downloaderB */
         $downloaderB = $this->getMockBuilder(Downloader::class)
             ->setMockClassName(self::uniqueClassName(Downloader::class))
             ->getMock();

--- a/tests/Driver/DriverFactoryTest.php
+++ b/tests/Driver/DriverFactoryTest.php
@@ -23,9 +23,9 @@ final class DriverFactoryTest extends TestCase
     /**
      * @dataProvider createFromBrowserDataProvider
      */
-    public function testCreateFromBrowser(Driver $expectedDriver, Browser $browser) : void
+    public function testCreateFromBrowser(Driver $expectedDriver, Browser $browser): void
     {
-        $versionResolver = $this->createMock(VersionResolver::class);
+        $versionResolver = $this->createStub(VersionResolver::class);
         $versionResolver->method('fromBrowser')->willReturn(Version::fromString('1.0.0'));
         $versionResolver->method('supports')->willReturn(true);
 
@@ -38,7 +38,7 @@ final class DriverFactoryTest extends TestCase
         self::assertSameDriver($expectedDriver, $driver);
     }
 
-    private static function assertSameDriver(Driver $expected, Driver $actual) : void
+    private static function assertSameDriver(Driver $expected, Driver $actual): void
     {
         self::assertTrue($expected->name()->equals($actual->name()));
         self::assertSame($expected->version()->toBuildString(), $actual->version()->toBuildString());
@@ -50,7 +50,7 @@ final class DriverFactoryTest extends TestCase
      *
      * @psalm-return array<string, array{Driver, Browser}>
      */
-    public function createFromBrowserDataProvider() : array
+    public function createFromBrowserDataProvider(): array
     {
         return [
             'google_chrome' => [

--- a/tests/Driver/GeckoDriver/DownloaderTest.php
+++ b/tests/Driver/GeckoDriver/DownloaderTest.php
@@ -11,11 +11,14 @@ use DBrekelmans\BrowserDriverInstaller\Driver\GeckoDriver\Downloader;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Version;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use const DIRECTORY_SEPARATOR;
+
 use function sys_get_temp_dir;
+
+use const DIRECTORY_SEPARATOR;
 
 class DownloaderTest extends TestCase
 {
@@ -23,34 +26,34 @@ class DownloaderTest extends TestCase
     private $downloader;
     /** @var Driver  */
     private $geckoMac;
-    /** @var MockObject&Filesystem */
+    /** @var Stub&Filesystem */
     private $filesystem;
     /** @var MockObject&HttpClientInterface */
     private $httpClient;
     /** @var Extractor&MockObject */
     private $archiveExtractor;
 
-    public function setUp() : void
+    public function setUp(): void
     {
-        $this->filesystem       = $this->createMock(Filesystem::class);
+        $this->filesystem       = $this->createStub(Filesystem::class);
         $this->httpClient       = $this->createMock(HttpClientInterface::class);
         $this->archiveExtractor = $this->createMock(Extractor::class);
         $this->downloader       = new Downloader($this->filesystem, $this->httpClient, $this->archiveExtractor);
         $this->geckoMac         = new Driver(DriverName::GECKO(), Version::fromString('0.27.0'), OperatingSystem::MACOS());
     }
 
-    public function testSupportGecko() : void
+    public function testSupportGecko(): void
     {
         self::assertTrue($this->downloader->supports($this->geckoMac));
     }
 
-    public function testDoesNotSupportChromeDriver() : void
+    public function testDoesNotSupportChromeDriver(): void
     {
         $chromeDriver = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::MACOS());
         self::assertFalse($this->downloader->supports($chromeDriver));
     }
 
-    public function testDownloadMac() : void
+    public function testDownloadMac(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload();
 
@@ -64,7 +67,7 @@ class DownloaderTest extends TestCase
         self::assertEquals('./geckodriver', $filePath);
     }
 
-    public function testDownloadLinux() : void
+    public function testDownloadLinux(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload();
 
@@ -79,7 +82,7 @@ class DownloaderTest extends TestCase
         self::assertEquals('./geckodriver', $filePath);
     }
 
-    public function testDownloadWindows() : void
+    public function testDownloadWindows(): void
     {
         $this->filesystem
             ->method('tempnam')
@@ -100,7 +103,7 @@ class DownloaderTest extends TestCase
         self::assertEquals('./geckodriver.exe', $filePath);
     }
 
-    private function mockFsAndArchiveExtractorForSuccessfulDownload() : void
+    private function mockFsAndArchiveExtractorForSuccessfulDownload(): void
     {
         $this->filesystem
             ->method('tempnam')

--- a/tests/Driver/GeckoDriver/VersionResolverTest.php
+++ b/tests/Driver/GeckoDriver/VersionResolverTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+
 use function Safe\file_get_contents;
 
 class VersionResolverTest extends TestCase
@@ -26,10 +27,10 @@ class VersionResolverTest extends TestCase
     /** @var Browser */
     private $firefox;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->httpClient      = new MockHttpClient(
-            static function (string $method, string $url) : MockResponse {
+            static function (string $method, string $url): MockResponse {
                 if ($method === 'GET' && $url === 'https://api.github.com/repos/mozilla/geckodriver/releases/latest') {
                     return new MockResponse(file_get_contents(__DIR__ . '/../../fixtures/githubResponseGeckoLatest.json'));
                 }
@@ -42,24 +43,24 @@ class VersionResolverTest extends TestCase
         $this->firefox         = new Browser(BrowserName::FIREFOX(), Version::fromString('81.0.2'), OperatingSystem::MACOS());
     }
 
-    public function testDoesNotSupportChrome() : void
+    public function testDoesNotSupportChrome(): void
     {
         self::assertFalse($this->versionResolver->supports($this->chrome));
     }
 
-    public function testSupportsFirefox() : void
+    public function testSupportsFirefox(): void
     {
         self::assertTrue($this->versionResolver->supports($this->firefox));
     }
 
-    public function testLatestVersionForRecentBrowser() : void
+    public function testLatestVersionForRecentBrowser(): void
     {
         $geckoVersion = $this->versionResolver->fromBrowser($this->firefox);
 
         self::assertEquals(Version::fromString('0.28.0'), $geckoVersion);
     }
 
-    public function testVersionForOldBrowser() : void
+    public function testVersionForOldBrowser(): void
     {
         $firefox = new Browser(BrowserName::FIREFOX(), Version::fromString('57.0.0'), OperatingSystem::MACOS());
 
@@ -68,7 +69,7 @@ class VersionResolverTest extends TestCase
         self::assertEquals(Version::fromString('0.25.0'), $geckoVersion);
     }
 
-    public function testNoVersionForVeryOldBrowser() : void
+    public function testNoVersionForVeryOldBrowser(): void
     {
         self::expectException(RuntimeException::class);
 

--- a/tests/Driver/VersionResolverFactoryTest.php
+++ b/tests/Driver/VersionResolverFactoryTest.php
@@ -12,14 +12,13 @@ use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Tests\UniqueClassName;
 use DBrekelmans\BrowserDriverInstaller\Version;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class VersionResolverFactoryTest extends TestCase
 {
     use UniqueClassName;
 
-    public function testNoVersionResolverImplemented() : void
+    public function testNoVersionResolverImplemented(): void
     {
         $factory = new VersionResolverFactory();
 
@@ -33,9 +32,9 @@ final class VersionResolverFactoryTest extends TestCase
         );
     }
 
-    public function testRegisteredVersionResolverIsReturned() : void
+    public function testRegisteredVersionResolverIsReturned(): void
     {
-        $versionResolver = $this->createMock(VersionResolver::class);
+        $versionResolver = $this->createStub(VersionResolver::class);
         $versionResolver->method('supports')->willReturn(true);
 
         $factory = new VersionResolverFactory();
@@ -53,21 +52,18 @@ final class VersionResolverFactoryTest extends TestCase
         );
     }
 
-    public function testSupportedVersionResolverIsReturned() : void
+    public function testSupportedVersionResolverIsReturned(): void
     {
-        /** @var VersionResolver&MockObject $versionResolverA */
         $versionResolverA = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverA->method('supports')->willReturn(false);
 
-        /** @var VersionResolver&MockObject $versionResolverB */
         $versionResolverB = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverB->method('supports')->willReturn(true);
 
-        /** @var VersionResolver&MockObject $versionResolverC */
         $versionResolverC = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
@@ -90,15 +86,13 @@ final class VersionResolverFactoryTest extends TestCase
         );
     }
 
-    public function testFirstSupportedVersionResolverIsReturned() : void
+    public function testFirstSupportedVersionResolverIsReturned(): void
     {
-        /** @var VersionResolver&MockObject $versionResolverA */
         $versionResolverA = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();
         $versionResolverA->method('supports')->willReturn(true);
 
-        /** @var VersionResolver&MockObject $versionResolverB */
         $versionResolverB = $this->getMockBuilder(VersionResolver::class)
             ->setMockClassName(self::uniqueClassName(VersionResolver::class))
             ->getMock();

--- a/tests/OperatingSystem/OperatingSystemTest.php
+++ b/tests/OperatingSystem/OperatingSystemTest.php
@@ -13,7 +13,7 @@ class OperatingSystemTest extends TestCase
     /**
      * @dataProvider fromFamilyDataProvider
      */
-    public function testFromFamily(OperatingSystem $expected, Family $family) : void
+    public function testFromFamily(OperatingSystem $expected, Family $family): void
     {
         self::assertTrue($expected->equals(OperatingSystem::fromFamily($family)));
     }
@@ -23,7 +23,7 @@ class OperatingSystemTest extends TestCase
      *
      * @psalm-return array<string, array{OperatingSystem, Family}>
      */
-    public function fromFamilyDataProvider() : array
+    public function fromFamilyDataProvider(): array
     {
         return [
             'windows' => [OperatingSystem::WINDOWS(), Family::WINDOWS()],

--- a/tests/UniqueClassName.php
+++ b/tests/UniqueClassName.php
@@ -14,7 +14,7 @@ trait UniqueClassName
     /**
      * @psalm-param class-string $className
      */
-    private static function uniqueClassName(string $className) : string
+    private static function uniqueClassName(string $className): string
     {
         $uniqueClassName = stripslashes(static::class) . stripslashes($className) . self::$uniqueClassNameCounter;
 


### PR DESCRIPTION
7.1 was causing issues with building the PHAR and is just annoying to support in general.

With the fact that bumping symfony/panther to 7.2 is accepted (https://github.com/symfony/panther/pull/389#issuecomment-744043089), I am reverting the support for 7.1