### PR TITLE
Improve version check in ChromeDriver VersionResolver

### DIFF
--- a/src/Driver/ChromeDriver/VersionResolver.php
+++ b/src/Driver/ChromeDriver/VersionResolver.php
@@ -27,7 +27,7 @@ final class VersionResolver implements VersionResolverInterface
     private const VERSION_ENDPOINT                 = 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE';
     private const VERSION_ENDPOINT_JSON            = 'https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json';
 
-    private HttpClientInterface $httpClient;
+    private $httpClient;
 
     public function __construct(HttpClientInterface $httpClient)
     {


### PR DESCRIPTION
Refactored the way versions are checked in the ChromeDriver's VersionResolver. Replaced array_key_exists() method with a sorted loop and version_compare() for increased accuracy and reliability when comparing versions. This ensures we choose the correct ChromeDriver version for a given browser version, and handles cases where the exact browser version may not be available, finding the closest match instead.

```
$ chromium --version
Chromium 119.0.5996.0
```

There is no `119.0.5996` in `https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json`, only `119.0.5997`

so taking closest possible better.