### PR TITLE
Feat/#94 resolve download url dynamically for chrome driver

### DIFF
--- a/bdi
+++ b/bdi
@@ -49,8 +49,10 @@ $geckoDriverVersionResolver = new GeckoDriver\VersionResolver($httpClient);
 $driverVersionResolverFactory->register($chromeDriverVersionResolver);
 $driverVersionResolverFactory->register($geckoDriverVersionResolver);
 
+$chromeDriverDownloadUrlResolver = new ChromeDriver\DownloadUrlResolver($httpClient);
+
 $driverDownloaderFactory = new Driver\DownloaderFactory();
-$driverDownloaderFactory->register(new ChromeDriver\Downloader($filesystem, $httpClient, $multiExtractor));
+$driverDownloaderFactory->register(new ChromeDriver\Downloader($filesystem, $httpClient, $multiExtractor, $chromeDriverDownloadUrlResolver));
 $driverDownloaderFactory->register(new GeckoDriver\Downloader($filesystem, $httpClient, $multiExtractor));
 
 $browserFactory = new Browser\BrowserFactory($browserPathResolverFactory, $browserVersionResolverFactory);

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -6,6 +6,8 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver;
 
 use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver as DownloadUrlResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
+use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
 
@@ -14,6 +16,9 @@ use function Safe\sprintf;
 
 final class DownloadUrlResolver implements DownloadUrlResolverInterface
 {
+    private const BINARY_LINUX                        = 'chromedriver_linux64';
+    private const BINARY_MAC                          = 'chromedriver_mac64';
+    private const BINARY_WINDOWS                      = 'chromedriver_win32';
     private const LEGACY_DOWNLOAD_ENDPOINT            = 'https://chromedriver.storage.googleapis.com';
     private const LATEST_PATCH_WITH_DOWNLOAD_ENDPOINT = 'https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json';
 
@@ -24,14 +29,14 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
         $this->httpClient = $httpClient;
     }
 
-    public function byDriver(Driver $driver, string $binaryName): string
+    public function byDriver(Driver $driver): string
     {
         if (! VersionResolver::isJsonVersion($driver->version())) {
             return sprintf(
                 '%s/%s/%s.zip',
                 self::LEGACY_DOWNLOAD_ENDPOINT,
                 $driver->version()->toBuildString(),
-                $binaryName
+                $this->getBinaryName($driver),
             );
         }
 
@@ -42,9 +47,10 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
             throw new UnexpectedValueException(sprintf('Could not find the chromedriver downloads for version %s', $driver->version()->toString()));
         }
 
-        $downloads = $versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'];
+        $platformName = $this->getPlatformName($driver);
+        $downloads    = $versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'];
         foreach ($downloads as $download) {
-            if ($download['platform'] === $binaryName && isset($download['url']) && is_string($download['url'])) {
+            if ($download['platform'] === $platformName && isset($download['url']) && is_string($download['url'])) {
                 return $download['url'];
             }
         }
@@ -56,5 +62,45 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
             $driver->version()->toString(),
             $operatingSystem->getValue()
         ));
+    }
+
+    private function getBinaryName(Driver $driver): string
+    {
+        $operatingSystem = $driver->operatingSystem();
+        if ($operatingSystem->equals(OperatingSystem::WINDOWS())) {
+            return self::BINARY_WINDOWS;
+        }
+
+        if ($operatingSystem->equals(OperatingSystem::MACOS())) {
+            return self::BINARY_MAC;
+        }
+
+        if ($operatingSystem->equals(OperatingSystem::LINUX())) {
+            return self::BINARY_LINUX;
+        }
+
+        throw NotImplemented::feature(
+            sprintf('Downloading %s for %s', $driver->name()->getValue(), $operatingSystem->getValue())
+        );
+    }
+
+    private function getPlatformName(Driver $driver): string
+    {
+        $operatingSystem = $driver->operatingSystem();
+        if ($operatingSystem->equals(OperatingSystem::WINDOWS())) {
+            return 'win32';
+        }
+
+        if ($operatingSystem->equals(OperatingSystem::MACOS())) {
+            return 'mac-x64';
+        }
+
+        if ($operatingSystem->equals(OperatingSystem::LINUX())) {
+            return 'linux64';
+        }
+
+        throw NotImplemented::feature(
+            sprintf('Downloading %s for %s', $driver->name()->getValue(), $operatingSystem->getValue())
+        );
     }
 }

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -6,10 +6,10 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver;
 
 use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver as DownloadUrlResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
-use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
 
+use function is_string;
 use function Safe\sprintf;
 
 final class DownloadUrlResolver implements DownloadUrlResolverInterface
@@ -47,13 +47,17 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
 
         $downloads = $versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'];
         foreach ($downloads as $download) {
-            if ($download['platform'] === $binaryName) {
-                return (string) $download['url'];
+            if ($download['platform'] === $binaryName && isset($download['url']) && is_string($download['url'])) {
+                return $download['url'];
             }
         }
 
         $operatingSystem = $driver->operatingSystem();
 
-        throw NotImplemented::feature(sprintf('Downloading %s for %s', $driver->name()->getValue(), $operatingSystem->getValue()));
+        throw new UnexpectedValueException(sprintf(
+            'Could not resolve chromedriver download url for version %s with binary %s',
+            $driver->version()->toString(),
+            $operatingSystem->getValue()
+        ));
     }
 }

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -35,10 +35,7 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
             );
         }
 
-        $response = $this->httpClient->request(
-            'GET',
-            self::LATEST_PATCH_WITH_DOWNLOAD_ENDPOINT,
-        );
+        $response = $this->httpClient->request('GET', self::LATEST_PATCH_WITH_DOWNLOAD_ENDPOINT);
 
         $versions = $response->toArray();
         if (! isset($versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'])) {

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver;
+
+use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver as DownloadUrlResolverInterface;
+use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
+use DBrekelmans\BrowserDriverInstaller\Exception\NotImplemented;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use UnexpectedValueException;
+
+use function Safe\sprintf;
+
+final class DownloadUrlResolver implements DownloadUrlResolverInterface
+{
+    private const LEGACY_DOWNLOAD_ENDPOINT            = 'https://chromedriver.storage.googleapis.com';
+    private const LATEST_PATCH_WITH_DOWNLOAD_ENDPOINT = 'https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json';
+
+    private HttpClientInterface $httpClient;
+
+    public function __construct(HttpClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function byDriver(Driver $driver, string $binaryName): string
+    {
+        if (! VersionResolver::isJsonVersion($driver->version())) {
+            return sprintf(
+                '%s/%s/%s.zip',
+                self::LEGACY_DOWNLOAD_ENDPOINT,
+                $driver->version()->toBuildString(),
+                $binaryName
+            );
+        }
+
+        $response = $this->httpClient->request(
+            'GET',
+            self::LATEST_PATCH_WITH_DOWNLOAD_ENDPOINT,
+        );
+
+        $versions = $response->toArray();
+        if (! isset($versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'])) {
+            throw new UnexpectedValueException(sprintf('Could not find the chromedriver downloads for version %s', $driver->version()->toString()));
+        }
+
+        $downloads = $versions['builds'][$driver->version()->toString()]['downloads']['chromedriver'];
+        foreach ($downloads as $download) {
+            if ($download['platform'] === $binaryName) {
+                return (string) $download['url'];
+            }
+        }
+
+        $operatingSystem = $driver->operatingSystem();
+
+        throw NotImplemented::feature(sprintf('Downloading %s for %s', $driver->name()->getValue(), $operatingSystem->getValue()));
+    }
+}

--- a/src/Driver/ChromeDriver/Downloader.php
+++ b/src/Driver/ChromeDriver/Downloader.php
@@ -32,9 +32,6 @@ use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
-    private const BINARY_LINUX        = 'chromedriver_linux64';
-    private const BINARY_MAC          = 'chromedriver_mac64';
-    private const BINARY_WINDOWS      = 'chromedriver_win32';
     private const BINARY_LINUX_JSON   = 'chromedriver-linux64';
     private const BINARY_MAC_JSON     = 'chromedriver-mac-x64';
     private const BINARY_WINDOWS_JSON = 'chromedriver-win32';
@@ -127,7 +124,7 @@ final class Downloader implements DownloaderInterface
 
         $response = $this->httpClient->request(
             'GET',
-            $this->downloadUrlResolver->byDriver($driver, $this->getBinaryName($driver)),
+            $this->downloadUrlResolver->byDriver($driver),
         );
 
         $fileHandler = fopen($temporaryFile, 'wb');
@@ -143,43 +140,6 @@ final class Downloader implements DownloaderInterface
         }
 
         return $temporaryFile;
-    }
-
-    /**
-     * @throws NotImplemented
-     */
-    private function getBinaryName(Driver $driver): string
-    {
-        $operatingSystem = $driver->operatingSystem();
-        if (VersionResolver::isJsonVersion($driver->version())) {
-            if ($operatingSystem->equals(OperatingSystem::WINDOWS())) {
-                return 'win32';
-            }
-
-            if ($operatingSystem->equals(OperatingSystem::MACOS())) {
-                return 'mac-x64';
-            }
-
-            if ($operatingSystem->equals(OperatingSystem::LINUX())) {
-                return 'linux64';
-            }
-        } else {
-            if ($operatingSystem->equals(OperatingSystem::WINDOWS())) {
-                return self::BINARY_WINDOWS;
-            }
-
-            if ($operatingSystem->equals(OperatingSystem::MACOS())) {
-                return self::BINARY_MAC;
-            }
-
-            if ($operatingSystem->equals(OperatingSystem::LINUX())) {
-                return self::BINARY_LINUX;
-            }
-        }
-
-        throw NotImplemented::feature(
-            sprintf('Downloading %s for %s', $driver->name()->getValue(), $operatingSystem->getValue())
-        );
     }
 
     /**

--- a/src/Driver/ChromeDriver/Downloader.php
+++ b/src/Driver/ChromeDriver/Downloader.php
@@ -32,12 +32,12 @@ use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
-    private const BINARY_LINUX                = 'chromedriver_linux64';
-    private const BINARY_MAC                  = 'chromedriver_mac64';
-    private const BINARY_WINDOWS              = 'chromedriver_win32';
-    private const BINARY_LINUX_JSON           = 'chromedriver-linux64';
-    private const BINARY_MAC_JSON             = 'chromedriver-mac-x64';
-    private const BINARY_WINDOWS_JSON         = 'chromedriver-win32';
+    private const BINARY_LINUX        = 'chromedriver_linux64';
+    private const BINARY_MAC          = 'chromedriver_mac64';
+    private const BINARY_WINDOWS      = 'chromedriver_win32';
+    private const BINARY_LINUX_JSON   = 'chromedriver-linux64';
+    private const BINARY_MAC_JSON     = 'chromedriver-mac-x64';
+    private const BINARY_WINDOWS_JSON = 'chromedriver-win32';
 
 
     private Filesystem $filesystem;
@@ -56,11 +56,11 @@ final class Downloader implements DownloaderInterface
         Extractor $archiveExtractor,
         DownloadUrlResolver $downloadUrlResolver
     ) {
-        $this->filesystem       = $filesystem;
-        $this->httpClient       = $httpClient;
-        $this->archiveExtractor = $archiveExtractor;
+        $this->filesystem          = $filesystem;
+        $this->httpClient          = $httpClient;
+        $this->archiveExtractor    = $archiveExtractor;
         $this->downloadUrlResolver = $downloadUrlResolver;
-        $this->tempDir          = sys_get_temp_dir();
+        $this->tempDir             = sys_get_temp_dir();
     }
 
     public function supports(Driver $driver): bool

--- a/src/Driver/ChromeDriver/VersionResolver.php
+++ b/src/Driver/ChromeDriver/VersionResolver.php
@@ -28,6 +28,11 @@ final class VersionResolver implements VersionResolverInterface
 
     private HttpClientInterface $httpClient;
 
+    public static function isJsonVersion(Version $version): bool
+    {
+        return $version->major() >= self::MAJOR_VERSION_ENDPOINT_BREAKPOINT;
+    }
+
     public function __construct(HttpClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;

--- a/src/Driver/DownloadUrlResolver.php
+++ b/src/Driver/DownloadUrlResolver.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBrekelmans\BrowserDriverInstaller\Driver;
+
+interface DownloadUrlResolver
+{
+    public function byDriver(Driver $driver, string $binaryName): string;
+}

--- a/src/Driver/DownloadUrlResolver.php
+++ b/src/Driver/DownloadUrlResolver.php
@@ -6,5 +6,5 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver;
 
 interface DownloadUrlResolver
 {
-    public function byDriver(Driver $driver, string $binaryName): string;
+    public function byDriver(Driver $driver): string;
 }

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver\ChromeDriver;
+
+use DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver\DownloadUrlResolver;
+use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
+use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
+use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
+use DBrekelmans\BrowserDriverInstaller\Version;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+use function Safe\json_encode;
+
+final class DownloadUrlResolverTest extends TestCase
+{
+    private DownloadUrlResolver $urlResolver;
+
+    /**
+     * @return iterable<string, array{0: Driver, 1: string, 2: string}>
+     */
+    public static function byDriverDataProvider(): iterable
+    {
+        yield 'legacy version' => [
+            new Driver(DriverName::CHROME(), Version::fromString('88.0.4299.0'), OperatingSystem::LINUX()),
+            'some_binary',
+            'https://chromedriver.storage.googleapis.com/88.0.4299.0/some_binary.zip',
+        ];
+
+        yield 'new version' => [
+            new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::LINUX()),
+            'linux64',
+            'https://dynamic-url-2/',
+        ];
+    }
+
+    /**
+     * @dataProvider byDriverDataProvider
+     */
+    public function testByDriver(Driver $driver, string $binaryName, string $expectedUrl): void
+    {
+        self::assertSame($expectedUrl, $this->urlResolver->byDriver($driver, $binaryName));
+    }
+
+    protected function setUp(): void
+    {
+        $httpClientMock = new MockHttpClient(
+            static function (string $method, string $url): MockResponse {
+                if ($method === 'GET') {
+                    if ($url === 'https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json') {
+                        return new MockResponse(
+                            json_encode([
+                                'builds' => [
+                                    '115.0.5790' => [
+                                        'downloads' => [
+                                            'chromedriver' => [
+                                                ['platform' => 'win32', 'url' => 'https://dynamic-url-1/'],
+                                                ['platform' => 'linux64', 'url' => 'https://dynamic-url-2/'],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ])
+                        );
+                    }
+                }
+
+                return new MockResponse(
+                    '<?xml version=\'1.0\' encoding=\'UTF-8\'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: chromedriver/LATEST_RELEASE_xxx</Details></Error>',
+                    ['http_code' => 404]
+                );
+            }
+        );
+
+        $this->urlResolver = new DownloadUrlResolver($httpClientMock);
+    }
+}

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -20,29 +20,47 @@ final class DownloadUrlResolverTest extends TestCase
     private DownloadUrlResolver $urlResolver;
 
     /**
-     * @return iterable<string, array{0: Driver, 1: string, 2: string}>
+     * @return iterable<string, array{0: Driver, 1: string}>
      */
     public static function byDriverDataProvider(): iterable
     {
-        yield 'legacy version' => [
+        yield 'legacy version linux' => [
             new Driver(DriverName::CHROME(), Version::fromString('88.0.4299.0'), OperatingSystem::LINUX()),
-            'some_binary',
-            'https://chromedriver.storage.googleapis.com/88.0.4299.0/some_binary.zip',
+            'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_linux64.zip',
         ];
 
-        yield 'new version' => [
+        yield 'legacy version macos' => [
+            new Driver(DriverName::CHROME(), Version::fromString('88.0.4299.0'), OperatingSystem::MACOS()),
+            'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_mac64.zip',
+        ];
+
+        yield 'legacy version windows' => [
+            new Driver(DriverName::CHROME(), Version::fromString('88.0.4299.0'), OperatingSystem::WINDOWS()),
+            'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_win32.zip',
+        ];
+
+        yield 'new version linux' => [
             new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::LINUX()),
-            'linux64',
             'https://dynamic-url-2/',
+        ];
+
+        yield 'new version macos' => [
+            new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::MACOS()),
+            'https://dynamic-url-3/',
+        ];
+
+        yield 'new version windows' => [
+            new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS()),
+            'https://dynamic-url-1/',
         ];
     }
 
     /**
      * @dataProvider byDriverDataProvider
      */
-    public function testByDriver(Driver $driver, string $binaryName, string $expectedUrl): void
+    public function testByDriver(Driver $driver, string $expectedUrl): void
     {
-        self::assertSame($expectedUrl, $this->urlResolver->byDriver($driver, $binaryName));
+        self::assertSame($expectedUrl, $this->urlResolver->byDriver($driver));
     }
 
     protected function setUp(): void
@@ -59,6 +77,7 @@ final class DownloadUrlResolverTest extends TestCase
                                             'chromedriver' => [
                                                 ['platform' => 'win32', 'url' => 'https://dynamic-url-1/'],
                                                 ['platform' => 'linux64', 'url' => 'https://dynamic-url-2/'],
+                                                ['platform' => 'mac-x64', 'url' => 'https://dynamic-url-3/'],
                                             ],
                                         ],
                                     ],

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -6,6 +6,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver\ChromeDriver;
 
 use DBrekelmans\BrowserDriverInstaller\Archive\Extractor;
 use DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver\Downloader;
+use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
@@ -30,6 +31,9 @@ class DownloaderTest extends TestCase
     /** @var Stub&Extractor */
     private $archiveExtractor;
 
+    /** @var MockObject&DownloadUrlResolver */
+    private $downloadUrlResolver;
+
     /** @var MockObject&HttpClientInterface */
     private $httpClient;
 
@@ -49,13 +53,20 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS());
 
+        $chromeDriverMac = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::MACOS());
+
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverMac, 'chromedriver_mac64')
+            ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_mac64.zip');
+
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
             ->with('GET', 'https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_mac64.zip');
 
-        $chromeDriverMac = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::MACOS());
-        $filePath        = $this->downloader->download($chromeDriverMac, '.');
+        $filePath = $this->downloader->download($chromeDriverMac, '.');
 
         self::assertEquals('./chromedriver', $filePath);
     }
@@ -64,28 +75,20 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS(), true);
 
-        $this->httpClient
-            ->expects(self::atLeastOnce())
-            ->method('request')
-            ->with('GET', 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/mac-x64/chromedriver-mac-x64.zip');
-
         $chromeDriverMac = new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::MACOS());
-        $filePath        = $this->downloader->download($chromeDriverMac, '.');
 
-        self::assertEquals('./chromedriver', $filePath);
-    }
-
-    public function testDownloadMacJsonNewEndpoint(): void
-    {
-        $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS(), true);
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverMac, 'mac-x64')
+            ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
-            ->with('GET', 'https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.0/mac-x64/chromedriver-mac-x64.zip');
+            ->with('GET', 'https://dynamic-download-url/driver.zip');
 
-        $chromeDriverMac = new Driver(DriverName::CHROME(), Version::fromString('121.0.6167.0'), OperatingSystem::MACOS());
-        $filePath        = $this->downloader->download($chromeDriverMac, '.');
+        $filePath = $this->downloader->download($chromeDriverMac, '.');
 
         self::assertEquals('./chromedriver', $filePath);
     }
@@ -94,13 +97,20 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX());
 
+        $chromeDriverLinux = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::LINUX());
+
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverLinux, 'chromedriver_linux64')
+            ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip');
+
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
             ->with('GET', 'https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip');
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::LINUX());
-        $filePath          = $this->downloader->download($chromeDriverLinux, '.');
+        $filePath = $this->downloader->download($chromeDriverLinux, '.');
 
         self::assertEquals('./chromedriver', $filePath);
     }
@@ -109,28 +119,20 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX(), true);
 
-        $this->httpClient
-            ->expects(self::atLeastOnce())
-            ->method('request')
-            ->with('GET', 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/linux64/chromedriver-linux64.zip');
-
         $chromeDriverLinux = new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::LINUX());
-        $filePath          = $this->downloader->download($chromeDriverLinux, '.');
 
-        self::assertEquals('./chromedriver', $filePath);
-    }
-
-    public function testDownloadLinuxJsonNewEndpoint(): void
-    {
-        $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX(), true);
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverLinux, 'linux64')
+            ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
-            ->with('GET', 'https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.0/linux64/chromedriver-linux64.zip');
+            ->with('GET', 'https://dynamic-download-url/driver.zip');
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME(), Version::fromString('121.0.6167.0'), OperatingSystem::LINUX());
-        $filePath          = $this->downloader->download($chromeDriverLinux, '.');
+        $filePath = $this->downloader->download($chromeDriverLinux, '.');
 
         self::assertEquals('./chromedriver', $filePath);
     }
@@ -139,13 +141,20 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS());
 
+        $chromeDriverWindows = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS());
+
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverWindows, 'chromedriver_win32')
+            ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_win32.zip');
+
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
             ->with('GET', 'https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_win32.zip');
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME(), Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS());
-        $filePath          = $this->downloader->download($chromeDriverLinux, '.');
+        $filePath = $this->downloader->download($chromeDriverWindows, '.');
 
         self::assertEquals('./chromedriver.exe', $filePath);
     }
@@ -154,38 +163,31 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS(), true);
 
-        $this->httpClient
-            ->expects(self::atLeastOnce())
-            ->method('request')
-            ->with('GET', 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.170/win32/chromedriver-win32.zip');
-
         $chromeDriverWindows = new Driver(DriverName::CHROME(), Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS());
-        $filePath            = $this->downloader->download($chromeDriverWindows, '.');
 
-        self::assertEquals('./chromedriver.exe', $filePath);
-    }
-
-    public function testDownloadWindowsJsonNewEndpoint(): void
-    {
-        $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS(), true);
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverWindows, 'win32')
+            ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient
             ->expects(self::atLeastOnce())
             ->method('request')
-            ->with('GET', 'https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.0/win32/chromedriver-win32.zip');
+            ->with('GET', 'https://dynamic-download-url/driver.zip');
 
-        $chromeDriverWindows = new Driver(DriverName::CHROME(), Version::fromString('121.0.6167.0'), OperatingSystem::WINDOWS());
-        $filePath            = $this->downloader->download($chromeDriverWindows, '.');
+        $filePath = $this->downloader->download($chromeDriverWindows, '.');
 
         self::assertEquals('./chromedriver.exe', $filePath);
     }
 
     protected function setUp(): void
     {
-        $this->filesystem       = $this->createStub(Filesystem::class);
-        $this->httpClient       = $this->createMock(HttpClientInterface::class);
-        $this->archiveExtractor = $this->createStub(Extractor::class);
-        $this->downloader       = new Downloader($this->filesystem, $this->httpClient, $this->archiveExtractor);
+        $this->filesystem          = $this->createStub(Filesystem::class);
+        $this->httpClient          = $this->createMock(HttpClientInterface::class);
+        $this->archiveExtractor    = $this->createStub(Extractor::class);
+        $this->downloadUrlResolver = $this->createMock(DownloadUrlResolver::class);
+        $this->downloader          = new Downloader($this->filesystem, $this->httpClient, $this->archiveExtractor, $this->downloadUrlResolver);
     }
 
     private function mockFsAndArchiveExtractorForSuccessfulDownload(

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -58,7 +58,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverMac, 'chromedriver_mac64')
+            ->with($chromeDriverMac)
             ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_mac64.zip');
 
         $this->httpClient
@@ -80,7 +80,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverMac, 'mac-x64')
+            ->with($chromeDriverMac)
             ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient
@@ -102,7 +102,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverLinux, 'chromedriver_linux64')
+            ->with($chromeDriverLinux)
             ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip');
 
         $this->httpClient
@@ -124,7 +124,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverLinux, 'linux64')
+            ->with($chromeDriverLinux)
             ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient
@@ -146,7 +146,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverWindows, 'chromedriver_win32')
+            ->with($chromeDriverWindows)
             ->willReturn('https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_win32.zip');
 
         $this->httpClient
@@ -168,7 +168,7 @@ class DownloaderTest extends TestCase
         $this->downloadUrlResolver
             ->expects(self::once())
             ->method('byDriver')
-            ->with($chromeDriverWindows, 'win32')
+            ->with($chromeDriverWindows)
             ->willReturn('https://dynamic-download-url/driver.zip');
 
         $this->httpClient

--- a/tests/Driver/ChromeDriver/VersionResolverTest.php
+++ b/tests/Driver/ChromeDriver/VersionResolverTest.php
@@ -81,6 +81,12 @@ class VersionResolverTest extends TestCase
         self::assertEquals(Version::fromString('86.0.4240.22'), $this->versionResolver->latest());
     }
 
+    public function testIsJsonVersion(): void
+    {
+        self::assertFalse(VersionResolver::isJsonVersion(Version::fromString('114.0.5735.90')));
+        self::assertTrue(VersionResolver::isJsonVersion(Version::fromString('115.0.5751')));
+    }
+
     protected function setUp(): void
     {
         $httpClientMock        = new MockHttpClient(


### PR DESCRIPTION
Fixes #94 

A rewrite of the logic for the chrome downloader, so the new chrome versions are now based on an api response. And we should no longer be able to run into the situation where the fetching breaks, if they suddenly change the download url.