### PR TITLE
doc: Add driver install directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Run `bdi` or `bdi detect` to automatically detect your installed browsers and in
 
 If you want to install any working driver for a specific browser, run `bdi browser:<browser-name>`.
 If you want to install a specific driver, run `bdi driver:<driver-name>` (defaults to the latest version. Use `--driver-version=<version>` to install a different version).
+You can specify a directory where the driver will be installed with `bdi detect <path-to-direcotry>`.
 
 For a full list of available commands, run `bdi list`.
 


### PR DESCRIPTION
Hello,

it seems that the parameter to specify the driver's installation directory is not available in the README.md documentation, it is a nice feature to have so I though this PR could improve the documentation

Regards