### PR TITLE
Added CPU architecture detection and option

### DIFF
--- a/src/Command/BrowserCommand.php
+++ b/src/Command/BrowserCommand.php
@@ -83,7 +83,7 @@ abstract class BrowserCommand extends Command
         $filePath         = $driverDownloader->download($driver, $installPath);
 
         $io->success(
-            sprintf('%s %s installed to %s', $driver->name->value, $driver->version->toBuildString(), $filePath),
+            sprintf('%s %s%s installed to %s', $driver->name->value, $driver->version->toBuildString(), $driver->cpuArchitecture->toCommandOutput(), $filePath),
         );
 
         return self::SUCCESS;

--- a/src/Command/BrowserCommand.php
+++ b/src/Command/BrowserCommand.php
@@ -83,7 +83,7 @@ abstract class BrowserCommand extends Command
         $filePath         = $driverDownloader->download($driver, $installPath);
 
         $io->success(
-            sprintf('%s %s%s installed to %s', $driver->name->value, $driver->version->toBuildString(), $driver->cpuArchitecture->toCommandOutput(), $filePath),
+            sprintf('%s %s%s installed to %s', $driver->name->value, $driver->version->toBuildString(), $driver->cpuArchitecture->toString(), $filePath),
         );
 
         return self::SUCCESS;

--- a/src/Command/DriverCommand.php
+++ b/src/Command/DriverCommand.php
@@ -40,6 +40,7 @@ abstract class DriverCommand extends Command
                     new Input\InstallPathArgument(),
                     new Input\VersionOption(),
                     new Input\OperatingSystemOption(),
+                    new Input\CpuArchitectureOption(),
                 ],
             ),
         );
@@ -54,6 +55,7 @@ abstract class DriverCommand extends Command
         $installPath     = Input\InstallPathArgument::value($input);
         $versionString   = Input\VersionOption::value($input);
         $operatingSystem = Input\OperatingSystemOption::value($input);
+        $cpuArchitecture = Input\CpuArchitectureOption::value($input);
 
         // TODO: move this into VersionOption class
         if ($versionString === Input\VersionOption::LATEST) {
@@ -68,7 +70,7 @@ abstract class DriverCommand extends Command
             $version = Version::fromString($versionString);
         }
 
-        $driver = new Driver($driverName, $version, $operatingSystem);
+        $driver = new Driver($driverName, $version, $operatingSystem, $cpuArchitecture);
 
         if ($io->isVerbose()) {
             $io->writeln(
@@ -81,9 +83,10 @@ abstract class DriverCommand extends Command
 
         $io->success(
             sprintf(
-                '%s %s installed to %s',
+                '%s %s%s installed to %s',
                 $driver->name->value,
                 $driver->version->toBuildString(),
+                $driver->cpuArchitecture->toCommandOutput(),
                 $filePath,
             ),
         );

--- a/src/Command/DriverCommand.php
+++ b/src/Command/DriverCommand.php
@@ -86,7 +86,7 @@ abstract class DriverCommand extends Command
                 '%s %s%s installed to %s',
                 $driver->name->value,
                 $driver->version->toBuildString(),
-                $driver->cpuArchitecture->toCommandOutput(),
+                $driver->cpuArchitecture->toString(),
                 $filePath,
             ),
         );

--- a/src/Command/Input/CpuArchitectureOption.php
+++ b/src/Command/Input/CpuArchitectureOption.php
@@ -9,6 +9,7 @@ use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use UnexpectedValueException;
+
 use function array_map;
 use function implode;
 use function is_string;

--- a/src/Command/Input/CpuArchitectureOption.php
+++ b/src/Command/Input/CpuArchitectureOption.php
@@ -6,7 +6,6 @@ namespace DBrekelmans\BrowserDriverInstaller\Command\Input;
 
 use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
-use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use UnexpectedValueException;
@@ -15,7 +14,7 @@ use function implode;
 use function is_string;
 use function sprintf;
 
-/** @implements Option<OperatingSystem> */
+/** @implements Option<CpuArchitecture> */
 final class CpuArchitectureOption extends InputOption implements Option
 {
     public function __construct()

--- a/src/Command/Input/CpuArchitectureOption.php
+++ b/src/Command/Input/CpuArchitectureOption.php
@@ -54,7 +54,7 @@ final class CpuArchitectureOption extends InputOption implements Option
 
     public function default(): string|null
     {
-        return CpuArchitecture::X86_64->value;
+        return CpuArchitecture::AMD64->value;
     }
 
     public static function value(InputInterface $input): CpuArchitecture

--- a/src/Command/Input/CpuArchitectureOption.php
+++ b/src/Command/Input/CpuArchitectureOption.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DBrekelmans\BrowserDriverInstaller\Command\Input;
+
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
+use DBrekelmans\BrowserDriverInstaller\Exception\UnexpectedType;
+use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use UnexpectedValueException;
+use function array_map;
+use function implode;
+use function is_string;
+use function sprintf;
+
+/** @implements Option<OperatingSystem> */
+final class CpuArchitectureOption extends InputOption implements Option
+{
+    public function __construct()
+    {
+        parent::__construct(
+            self::name(),
+            $this->shortcut(),
+            $this->mode()->value,
+            $this->description(),
+            $this->default(),
+        );
+    }
+
+    public static function name(): string
+    {
+        return 'arch';
+    }
+
+    public function shortcut(): string|null
+    {
+        return null;
+    }
+
+    public function mode(): OptionMode
+    {
+        return OptionMode::REQUIRED;
+    }
+
+    public function description(): string
+    {
+        return sprintf(
+            'CPU architecture for which to install the driver (%s)',
+            implode('|', array_map(static fn ($case) => $case->value, CpuArchitecture::cases())),
+        );
+    }
+
+    public function default(): string|null
+    {
+        return CpuArchitecture::X86_64->value;
+    }
+
+    public static function value(InputInterface $input): CpuArchitecture
+    {
+        $value = $input->getOption(self::name());
+
+        if (! is_string($value)) {
+            throw UnexpectedType::expected('string', $value);
+        }
+
+        if (CpuArchitecture::tryFrom($value) === null) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Unexpected value %s. Expected one of: %s',
+                    $value,
+                    implode(', ', array_map(static fn ($case) => $case->value, CpuArchitecture::cases())),
+                ),
+            );
+        }
+
+        return CpuArchitecture::from($value);
+    }
+}

--- a/src/Cpu/CpuArchitecture.php
+++ b/src/Cpu/CpuArchitecture.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DBrekelmans\BrowserDriverInstaller\Cpu;
+
+enum CpuArchitecture: string
+{
+    case X86_64 = 'x86_64';
+    case ARM64  = 'arm64';
+
+    public function toCommandOutput(): string
+    {
+        return match ($this) {
+            self::X86_64 => '',
+            self::ARM64  => ' arm64',
+        };
+    }
+
+    public static function detectFromPhp(): CpuArchitecture
+    {
+        return match (php_uname('m')) {
+            'arm64', 'aarch64' => CpuArchitecture::ARM64,
+            default => CpuArchitecture::X86_64,
+        };
+    }
+}

--- a/src/Cpu/CpuArchitecture.php
+++ b/src/Cpu/CpuArchitecture.php
@@ -1,6 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DBrekelmans\BrowserDriverInstaller\Cpu;
+
+use function php_uname;
 
 enum CpuArchitecture: string
 {

--- a/src/Cpu/CpuArchitecture.php
+++ b/src/Cpu/CpuArchitecture.php
@@ -9,13 +9,13 @@ use function php_uname;
 enum CpuArchitecture: string
 {
     case AMD64 = 'amd64';
-    case ARM64  = 'arm64';
+    case ARM64 = 'arm64';
 
     public function toString(): string
     {
         return match ($this) {
             self::AMD64 => ' amd64',
-            self::ARM64  => ' arm64',
+            self::ARM64 => ' arm64',
         };
     }
 

--- a/src/Cpu/CpuArchitecture.php
+++ b/src/Cpu/CpuArchitecture.php
@@ -8,13 +8,13 @@ use function php_uname;
 
 enum CpuArchitecture: string
 {
-    case X86_64 = 'x86_64';
+    case AMD64 = 'amd64';
     case ARM64  = 'arm64';
 
     public function toString(): string
     {
         return match ($this) {
-            self::X86_64 => '',
+            self::AMD64 => ' amd64',
             self::ARM64  => ' arm64',
         };
     }
@@ -23,7 +23,7 @@ enum CpuArchitecture: string
     {
         return match (php_uname('m')) {
             'arm64', 'aarch64' => CpuArchitecture::ARM64,
-            default => CpuArchitecture::X86_64,
+            default => CpuArchitecture::AMD64,
         };
     }
 }

--- a/src/Cpu/CpuArchitecture.php
+++ b/src/Cpu/CpuArchitecture.php
@@ -7,7 +7,7 @@ enum CpuArchitecture: string
     case X86_64 = 'x86_64';
     case ARM64  = 'arm64';
 
-    public function toCommandOutput(): string
+    public function toString(): string
     {
         return match ($this) {
             self::X86_64 => '',

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver;
 
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver as DownloadUrlResolverInterface;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
-
 use function is_string;
 use function sprintf;
 
@@ -40,6 +40,10 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
             throw new UnexpectedValueException(sprintf('Could not find the chromedriver downloads for version %s', $driver->version->toString()));
         }
 
+        if ($driver->cpuArchitecture === CpuArchitecture::ARM64 && $driver->operatingSystem !== OperatingSystem::MACOS) {
+            throw new UnexpectedValueException('Chromedriver ARM64 is only available on macOS.');
+        }
+
         $platformName = $this->getPlatformName($driver);
         $downloads    = $versions['builds'][$driver->version->toString()]['downloads']['chromedriver'];
         foreach ($downloads as $download) {
@@ -59,6 +63,9 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
 
     private function getBinaryName(Driver $driver): string
     {
+        if ($driver->operatingSystem === OperatingSystem::MACOS && $driver->cpuArchitecture === CpuArchitecture::ARM64) {
+            return 'chromedriver_mac_arm64';
+        }
         return match ($driver->operatingSystem) {
             OperatingSystem::LINUX => 'chromedriver_linux64',
             OperatingSystem::MACOS => 'chromedriver_mac64',
@@ -68,6 +75,9 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
 
     private function getPlatformName(Driver $driver): string
     {
+        if ($driver->cpuArchitecture === CpuArchitecture::ARM64) {
+            return 'mac-arm64';
+        }
         return match ($driver->operatingSystem) {
             OperatingSystem::LINUX => 'linux64',
             OperatingSystem::MACOS => 'mac-x64',

--- a/src/Driver/ChromeDriver/DownloadUrlResolver.php
+++ b/src/Driver/ChromeDriver/DownloadUrlResolver.php
@@ -10,6 +10,7 @@ use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
+
 use function is_string;
 use function sprintf;
 
@@ -66,6 +67,7 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
         if ($driver->operatingSystem === OperatingSystem::MACOS && $driver->cpuArchitecture === CpuArchitecture::ARM64) {
             return 'chromedriver_mac_arm64';
         }
+
         return match ($driver->operatingSystem) {
             OperatingSystem::LINUX => 'chromedriver_linux64',
             OperatingSystem::MACOS => 'chromedriver_mac64',
@@ -78,6 +80,7 @@ final class DownloadUrlResolver implements DownloadUrlResolverInterface
         if ($driver->cpuArchitecture === CpuArchitecture::ARM64) {
             return 'mac-arm64';
         }
+
         return match ($driver->operatingSystem) {
             OperatingSystem::LINUX => 'linux64',
             OperatingSystem::MACOS => 'mac-x64',

--- a/src/Driver/ChromeDriver/Downloader.php
+++ b/src/Driver/ChromeDriver/Downloader.php
@@ -19,6 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
+
 use function in_array;
 use function Safe\fclose;
 use function Safe\fopen;
@@ -26,6 +27,7 @@ use function Safe\fwrite;
 use function sprintf;
 use function str_replace;
 use function sys_get_temp_dir;
+
 use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
@@ -46,6 +48,7 @@ final class Downloader implements DownloaderInterface
         if ($driver->cpuArchitecture === CpuArchitecture::ARM64 && $driver->operatingSystem !== OperatingSystem::MACOS) {
             return false;
         }
+
         return $driver->name === DriverName::CHROME;
     }
 

--- a/src/Driver/ChromeDriver/Downloader.php
+++ b/src/Driver/ChromeDriver/Downloader.php
@@ -43,7 +43,7 @@ final class Downloader implements DownloaderInterface
 
     public function supports(Driver $driver): bool
     {
-        if ($driver->cpuArchitecture === CpuArchitecture::ARM64 && $driver->operatingSystem === OperatingSystem::LINUX) {
+        if ($driver->cpuArchitecture === CpuArchitecture::ARM64 && $driver->operatingSystem !== OperatingSystem::MACOS) {
             return false;
         }
         return $driver->name === DriverName::CHROME;

--- a/src/Driver/DownloaderFactory.php
+++ b/src/Driver/DownloaderFactory.php
@@ -21,7 +21,7 @@ final class DownloaderFactory
             }
         }
 
-        throw NotImplemented::feature(sprintf('Downloader for %s', $driver->name->value));
+        throw NotImplemented::feature(sprintf('Downloader for %s %s', $driver->name->value, $driver->cpuArchitecture->value));
     }
 
     public function register(Downloader $downloader, string|null $identifier = null): void

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DBrekelmans\BrowserDriverInstaller\Driver;
 
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\OperatingSystem\OperatingSystem;
 use DBrekelmans\BrowserDriverInstaller\Version;
 
@@ -13,6 +14,7 @@ final class Driver
         public readonly DriverName $name,
         public readonly Version $version,
         public readonly OperatingSystem $operatingSystem,
+        public readonly CpuArchitecture $cpuArchitecture,
     ) {
     }
 }

--- a/src/Driver/DriverFactory.php
+++ b/src/Driver/DriverFactory.php
@@ -6,6 +6,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Driver;
 
 use DBrekelmans\BrowserDriverInstaller\Browser\Browser;
 use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 
 final class DriverFactory
 {
@@ -20,7 +21,10 @@ final class DriverFactory
 
         $name = $this->getDriverNameForBrowser($browser);
 
-        return new Driver($name, $version, $browser->operatingSystem);
+        // Detect CPU arch
+        $cpuArchitecture = CpuArchitecture::detectFromPhp();
+
+        return new Driver($name, $version, $browser->operatingSystem, $cpuArchitecture);
     }
 
     private function getDriverNameForBrowser(Browser $browser): DriverName

--- a/src/Driver/GeckoDriver/Downloader.php
+++ b/src/Driver/GeckoDriver/Downloader.php
@@ -17,6 +17,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 use function basename;
 use function dirname;
 use function Safe\fclose;
@@ -25,38 +26,38 @@ use function Safe\fwrite;
 use function sprintf;
 use function str_contains;
 use function sys_get_temp_dir;
+
 use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
     private const DOWNLOAD_PATH_OS_PART_WINDOWS = 'win';
-    private const DOWNLOAD_PATH_OS_PART_MACOS = 'macos';
-    private const DOWNLOAD_PATH_OS_PART_LINUX = 'linux';
-    private const DOWNLOAD_BASE_PATH = 'https://github.com/mozilla/geckodriver/releases/download/';
+    private const DOWNLOAD_PATH_OS_PART_MACOS   = 'macos';
+    private const DOWNLOAD_PATH_OS_PART_LINUX   = 'linux';
+    private const DOWNLOAD_BASE_PATH            = 'https://github.com/mozilla/geckodriver/releases/download/';
 
     public function __construct(
-        private readonly Filesystem          $filesystem,
+        private readonly Filesystem $filesystem,
         private readonly HttpClientInterface $httpClient,
-        private readonly Extractor           $archiveExtractor,
-    )
-    {
+        private readonly Extractor $archiveExtractor,
+    ) {
     }
 
     public function download(Driver $driver, string $location): string
     {
         try {
             $archive = $this->downloadArchive($driver);
-        } catch (NotImplemented|FilesystemException|IOException|TransportExceptionInterface $exception) {
+        } catch (NotImplemented | FilesystemException | IOException | TransportExceptionInterface $exception) {
             throw new RuntimeException('Something went wrong downloading the geckodriver archive.', 0, $exception);
         }
 
         try {
             $binary = $this->extractArchive($archive);
-        } catch (IOException|RuntimeException $exception) {
+        } catch (IOException | RuntimeException $exception) {
             throw new RuntimeException('Something went wrong extracting the geckodriver archive.', 0, $exception);
         }
 
-        if (!$this->filesystem->exists($location)) {
+        if (! $this->filesystem->exists($location)) {
             $this->filesystem->mkdir($location);
         }
 
@@ -112,13 +113,13 @@ final class Downloader implements DownloaderInterface
     private function getDownloadPath(Driver $driver): string
     {
         return self::DOWNLOAD_BASE_PATH . sprintf(
-                'v%s/geckodriver-v%s-%s%s%s',
-                $driver->version->toString(),
-                $driver->version->toString(),
-                $this->getOsForDownloadPath($driver),
-                $this->getCpuArchForDownloadPath($driver),
-                $this->getArchiveExtension($driver),
-            );
+            'v%s/geckodriver-v%s-%s%s%s',
+            $driver->version->toString(),
+            $driver->version->toString(),
+            $this->getOsForDownloadPath($driver),
+            $this->getCpuArchForDownloadPath($driver),
+            $this->getArchiveExtension($driver),
+        );
     }
 
     private function getOsForDownloadPath(Driver $driver): string
@@ -138,12 +139,14 @@ final class Downloader implements DownloaderInterface
                 CpuArchitecture::ARM64 => '-aarch64',
             };
         }
+
         if ($driver->operatingSystem === OperatingSystem::MACOS) {
             return match ($driver->cpuArchitecture) {
                 CpuArchitecture::X86_64 => '',
                 CpuArchitecture::ARM64 => '-aarch64',
             };
         }
+
         // Windows
         return match ($driver->cpuArchitecture) {
             CpuArchitecture::X86_64 => '64',

--- a/src/Driver/GeckoDriver/Downloader.php
+++ b/src/Driver/GeckoDriver/Downloader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Driver\GeckoDriver;
 
 use DBrekelmans\BrowserDriverInstaller\Archive\Extractor;
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\Downloader as DownloaderInterface;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
@@ -16,7 +17,6 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-
 use function basename;
 use function dirname;
 use function Safe\fclose;
@@ -25,38 +25,38 @@ use function Safe\fwrite;
 use function sprintf;
 use function str_contains;
 use function sys_get_temp_dir;
-
 use const DIRECTORY_SEPARATOR;
 
 final class Downloader implements DownloaderInterface
 {
-    private const DOWNLOAD_PATH_OS_PART_WINDOWS = 'win64';
-    private const DOWNLOAD_PATH_OS_PART_MACOS   = 'macos';
-    private const DOWNLOAD_PATH_OS_PART_LINUX   = 'linux64';
-    private const DOWNLOAD_BASE_PATH            = 'https://github.com/mozilla/geckodriver/releases/download/';
+    private const DOWNLOAD_PATH_OS_PART_WINDOWS = 'win';
+    private const DOWNLOAD_PATH_OS_PART_MACOS = 'macos';
+    private const DOWNLOAD_PATH_OS_PART_LINUX = 'linux';
+    private const DOWNLOAD_BASE_PATH = 'https://github.com/mozilla/geckodriver/releases/download/';
 
     public function __construct(
-        private readonly Filesystem $filesystem,
+        private readonly Filesystem          $filesystem,
         private readonly HttpClientInterface $httpClient,
-        private readonly Extractor $archiveExtractor,
-    ) {
+        private readonly Extractor           $archiveExtractor,
+    )
+    {
     }
 
     public function download(Driver $driver, string $location): string
     {
         try {
             $archive = $this->downloadArchive($driver);
-        } catch (NotImplemented | FilesystemException | IOException | TransportExceptionInterface $exception) {
+        } catch (NotImplemented|FilesystemException|IOException|TransportExceptionInterface $exception) {
             throw new RuntimeException('Something went wrong downloading the geckodriver archive.', 0, $exception);
         }
 
         try {
             $binary = $this->extractArchive($archive);
-        } catch (IOException | RuntimeException $exception) {
+        } catch (IOException|RuntimeException $exception) {
             throw new RuntimeException('Something went wrong extracting the geckodriver archive.', 0, $exception);
         }
 
-        if (! $this->filesystem->exists($location)) {
+        if (!$this->filesystem->exists($location)) {
             $this->filesystem->mkdir($location);
         }
 
@@ -112,12 +112,13 @@ final class Downloader implements DownloaderInterface
     private function getDownloadPath(Driver $driver): string
     {
         return self::DOWNLOAD_BASE_PATH . sprintf(
-            'v%s/geckodriver-v%s-%s%s',
-            $driver->version->toString(),
-            $driver->version->toString(),
-            $this->getOsForDownloadPath($driver),
-            $this->getArchiveExtension($driver),
-        );
+                'v%s/geckodriver-v%s-%s%s%s',
+                $driver->version->toString(),
+                $driver->version->toString(),
+                $this->getOsForDownloadPath($driver),
+                $this->getCpuArchForDownloadPath($driver),
+                $this->getArchiveExtension($driver),
+            );
     }
 
     private function getOsForDownloadPath(Driver $driver): string
@@ -126,6 +127,27 @@ final class Downloader implements DownloaderInterface
             OperatingSystem::WINDOWS => self::DOWNLOAD_PATH_OS_PART_WINDOWS,
             OperatingSystem::MACOS => self::DOWNLOAD_PATH_OS_PART_MACOS,
             OperatingSystem::LINUX => self::DOWNLOAD_PATH_OS_PART_LINUX,
+        };
+    }
+
+    private function getCpuArchForDownloadPath(Driver $driver): string
+    {
+        if ($driver->operatingSystem === OperatingSystem::LINUX) {
+            return match ($driver->cpuArchitecture) {
+                CpuArchitecture::X86_64 => '64',
+                CpuArchitecture::ARM64 => '-aarch64',
+            };
+        }
+        if ($driver->operatingSystem === OperatingSystem::MACOS) {
+            return match ($driver->cpuArchitecture) {
+                CpuArchitecture::X86_64 => '',
+                CpuArchitecture::ARM64 => '-aarch64',
+            };
+        }
+        // Windows
+        return match ($driver->cpuArchitecture) {
+            CpuArchitecture::X86_64 => '64',
+            CpuArchitecture::ARM64 => '-aarch64',
         };
     }
 

--- a/src/Driver/GeckoDriver/Downloader.php
+++ b/src/Driver/GeckoDriver/Downloader.php
@@ -135,21 +135,21 @@ final class Downloader implements DownloaderInterface
     {
         if ($driver->operatingSystem === OperatingSystem::LINUX) {
             return match ($driver->cpuArchitecture) {
-                CpuArchitecture::X86_64 => '64',
+                CpuArchitecture::AMD64 => '64',
                 CpuArchitecture::ARM64 => '-aarch64',
             };
         }
 
         if ($driver->operatingSystem === OperatingSystem::MACOS) {
             return match ($driver->cpuArchitecture) {
-                CpuArchitecture::X86_64 => '',
+                CpuArchitecture::AMD64 => '',
                 CpuArchitecture::ARM64 => '-aarch64',
             };
         }
 
         // Windows
         return match ($driver->cpuArchitecture) {
-            CpuArchitecture::X86_64 => '64',
+            CpuArchitecture::AMD64 => '64',
             CpuArchitecture::ARM64 => '-aarch64',
         };
     }

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -25,27 +25,27 @@ final class DownloadUrlResolverTest extends TestCase
     public static function byDriverDataProvider(): iterable
     {
         yield 'legacy version linux' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_linux64.zip',
         ];
 
         yield 'legacy version macos' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::MACOS, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::MACOS, CpuArchitecture::AMD64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_mac64.zip',
         ];
 
         yield 'legacy version windows' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::WINDOWS, CpuArchitecture::AMD64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_win32.zip',
         ];
 
         yield 'new version linux' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
             'https://dynamic-url-2/',
         ];
 
         yield 'new version macos x86_64' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::AMD64),
             'https://dynamic-url-3/',
         ];
 
@@ -55,7 +55,7 @@ final class DownloadUrlResolverTest extends TestCase
         ];
 
         yield 'new version windows' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::AMD64),
             'https://dynamic-url-1/',
         ];
     }

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -43,9 +43,14 @@ final class DownloadUrlResolverTest extends TestCase
             'https://dynamic-url-2/',
         ];
 
-        yield 'new version macos' => [
+        yield 'new version macos x86_64' => [
             new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::X86_64),
             'https://dynamic-url-3/',
+        ];
+
+        yield 'new version macos arm64' => [
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::ARM64),
+            'https://dynamic-url-4/',
         ];
 
         yield 'new version windows' => [
@@ -75,6 +80,7 @@ final class DownloadUrlResolverTest extends TestCase
                                                 ['platform' => 'win32', 'url' => 'https://dynamic-url-1/'],
                                                 ['platform' => 'linux64', 'url' => 'https://dynamic-url-2/'],
                                                 ['platform' => 'mac-x64', 'url' => 'https://dynamic-url-3/'],
+                                                ['platform' => 'mac-arm64', 'url' => 'https://dynamic-url-4/'],
                                             ],
                                         ],
                                     ],

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver\ChromeDriver;
 
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver\DownloadUrlResolver;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
@@ -13,7 +14,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
-
 use function Safe\json_encode;
 
 final class DownloadUrlResolverTest extends TestCase
@@ -24,32 +24,32 @@ final class DownloadUrlResolverTest extends TestCase
     public static function byDriverDataProvider(): iterable
     {
         yield 'legacy version linux' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::LINUX),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_linux64.zip',
         ];
 
         yield 'legacy version macos' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::MACOS),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::MACOS, CpuArchitecture::X86_64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_mac64.zip',
         ];
 
         yield 'legacy version windows' => [
-            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::WINDOWS),
+            new Driver(DriverName::CHROME, Version::fromString('88.0.4299.0'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64),
             'https://chromedriver.storage.googleapis.com/88.0.4299.0/chromedriver_win32.zip',
         ];
 
         yield 'new version linux' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
             'https://dynamic-url-2/',
         ];
 
         yield 'new version macos' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::X86_64),
             'https://dynamic-url-3/',
         ];
 
         yield 'new version windows' => [
-            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS),
+            new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64),
             'https://dynamic-url-1/',
         ];
     }

--- a/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
+++ b/tests/Driver/ChromeDriver/DownloadUrlResolverTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+
 use function Safe\json_encode;
 
 final class DownloadUrlResolverTest extends TestCase

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver\ChromeDriver;
 
 use DBrekelmans\BrowserDriverInstaller\Archive\Extractor;
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\ChromeDriver\Downloader;
 use DBrekelmans\BrowserDriverInstaller\Driver\DownloadUrlResolver;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
@@ -16,9 +17,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-
 use function sys_get_temp_dir;
-
 use const DIRECTORY_SEPARATOR;
 
 class DownloaderTest extends TestCase
@@ -35,13 +34,19 @@ class DownloaderTest extends TestCase
 
     public function testSupportChrome(): void
     {
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
         self::assertTrue($this->downloader->supports($chromeDriverLinux));
+    }
+
+    public function testDoesNotSupportChromeArm64(): void
+    {
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::ARM64);
+        self::assertFalse($this->downloader->supports($chromeDriverLinux));
     }
 
     public function testDoesNotSupportGecko(): void
     {
-        $geckoDriver = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX);
+        $geckoDriver = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
         self::assertFalse($this->downloader->supports($geckoDriver));
     }
 
@@ -49,7 +54,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS);
 
-        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS);
+        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -67,11 +72,33 @@ class DownloaderTest extends TestCase
         self::assertEquals('./chromedriver', $filePath);
     }
 
+    public function testDownloadMacARM64(): void
+    {
+        $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS);
+
+        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('106.0.5249.61'), OperatingSystem::MACOS, CpuArchitecture::ARM64);
+
+        $this->downloadUrlResolver
+            ->expects(self::once())
+            ->method('byDriver')
+            ->with($chromeDriverMac)
+            ->willReturn('https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_mac_arm64.zip');
+
+        $this->httpClient
+            ->expects(self::atLeastOnce())
+            ->method('request')
+            ->with('GET', 'https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_mac_arm64.zip');
+
+        $filePath = $this->downloader->download($chromeDriverMac, '.');
+
+        self::assertEquals('./chromedriver', $filePath);
+    }
+
     public function testDownloadMacJson(): void
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS, true);
 
-        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS);
+        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -93,7 +120,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX);
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -115,7 +142,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX, true);
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -137,7 +164,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS);
 
-        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS);
+        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -159,7 +186,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS, true);
 
-        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS);
+        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64);
 
         $this->downloadUrlResolver
             ->expects(self::once())

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -17,7 +17,9 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 use function sys_get_temp_dir;
+
 use const DIRECTORY_SEPARATOR;
 
 class DownloaderTest extends TestCase

--- a/tests/Driver/ChromeDriver/DownloaderTest.php
+++ b/tests/Driver/ChromeDriver/DownloaderTest.php
@@ -36,7 +36,7 @@ class DownloaderTest extends TestCase
 
     public function testSupportChrome(): void
     {
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::AMD64);
         self::assertTrue($this->downloader->supports($chromeDriverLinux));
     }
 
@@ -48,7 +48,7 @@ class DownloaderTest extends TestCase
 
     public function testDoesNotSupportGecko(): void
     {
-        $geckoDriver = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
+        $geckoDriver = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64);
         self::assertFalse($this->downloader->supports($geckoDriver));
     }
 
@@ -56,7 +56,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS);
 
-        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
+        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -100,7 +100,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::MACOS, true);
 
-        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
+        $chromeDriverMac = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::MACOS, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -122,7 +122,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX);
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::LINUX, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -144,7 +144,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::LINUX, true);
 
-        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
+        $chromeDriverLinux = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::LINUX, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -166,7 +166,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS);
 
-        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64);
+        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::WINDOWS, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())
@@ -188,7 +188,7 @@ class DownloaderTest extends TestCase
     {
         $this->mockFsAndArchiveExtractorForSuccessfulDownload(OperatingSystem::WINDOWS, true);
 
-        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64);
+        $chromeDriverWindows = new Driver(DriverName::CHROME, Version::fromString('115.0.5790.170'), OperatingSystem::WINDOWS, CpuArchitecture::AMD64);
 
         $this->downloadUrlResolver
             ->expects(self::once())

--- a/tests/Driver/DownloaderFactoryTest.php
+++ b/tests/Driver/DownloaderFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver;
 
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\Downloader;
 use DBrekelmans\BrowserDriverInstaller\Driver\DownloaderFactory;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
@@ -21,7 +22,7 @@ final class DownloaderFactoryTest extends TestCase
 
         $this->expectException(NotImplemented::class);
         $factory->createFromDriver(
-            new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+            new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
         );
     }
 
@@ -36,7 +37,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloader,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
             ),
         );
     }
@@ -60,7 +61,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloaderB,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
             ),
         );
     }
@@ -80,7 +81,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloaderA,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
             ),
         );
     }

--- a/tests/Driver/DownloaderFactoryTest.php
+++ b/tests/Driver/DownloaderFactoryTest.php
@@ -22,7 +22,7 @@ final class DownloaderFactoryTest extends TestCase
 
         $this->expectException(NotImplemented::class);
         $factory->createFromDriver(
-            new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+            new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
         );
     }
 
@@ -37,7 +37,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloader,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
             ),
         );
     }
@@ -61,7 +61,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloaderB,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
             ),
         );
     }
@@ -81,7 +81,7 @@ final class DownloaderFactoryTest extends TestCase
         self::assertSame(
             $downloaderA,
             $factory->createFromDriver(
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64),
             ),
         );
     }

--- a/tests/Driver/DriverFactoryTest.php
+++ b/tests/Driver/DriverFactoryTest.php
@@ -6,6 +6,7 @@ namespace DBrekelmans\BrowserDriverInstaller\Tests\Driver;
 
 use DBrekelmans\BrowserDriverInstaller\Browser\Browser;
 use DBrekelmans\BrowserDriverInstaller\Browser\BrowserName;
+use DBrekelmans\BrowserDriverInstaller\Cpu\CpuArchitecture;
 use DBrekelmans\BrowserDriverInstaller\Driver\Driver;
 use DBrekelmans\BrowserDriverInstaller\Driver\DriverFactory;
 use DBrekelmans\BrowserDriverInstaller\Driver\DriverName;
@@ -39,22 +40,25 @@ final class DriverFactoryTest extends TestCase
         self::assertSame($expected->name, $actual->name);
         self::assertSame($expected->version->toBuildString(), $actual->version->toBuildString());
         self::assertSame($expected->operatingSystem, $actual->operatingSystem);
+        self::assertSame($expected->cpuArchitecture, $actual->cpuArchitecture);
     }
 
     /** @return array<string, array{Driver, Browser}> */
     public static function createFromBrowserDataProvider(): array
     {
+        $cpuArchitecture = CpuArchitecture::detectFromPhp();
+
         return [
             'google_chrome' => [
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, $cpuArchitecture),
                 new Browser(BrowserName::GOOGLE_CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
             ],
             'chromium' => [
-                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::CHROME, Version::fromString('1.0.0'), OperatingSystem::LINUX, $cpuArchitecture),
                 new Browser(BrowserName::CHROMIUM, Version::fromString('1.0.0'), OperatingSystem::LINUX),
             ],
             'firefox' => [
-                new Driver(DriverName::GECKO, Version::fromString('1.0.0'), OperatingSystem::LINUX),
+                new Driver(DriverName::GECKO, Version::fromString('1.0.0'), OperatingSystem::LINUX, $cpuArchitecture),
                 new Browser(BrowserName::FIREFOX, Version::fromString('1.0.0'), OperatingSystem::LINUX),
             ],
         ];

--- a/tests/Driver/GeckoDriver/DownloaderTest.php
+++ b/tests/Driver/GeckoDriver/DownloaderTest.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 use function sys_get_temp_dir;
+
 use const DIRECTORY_SEPARATOR;
 
 class DownloaderTest extends TestCase

--- a/tests/Driver/GeckoDriver/DownloaderTest.php
+++ b/tests/Driver/GeckoDriver/DownloaderTest.php
@@ -36,7 +36,7 @@ class DownloaderTest extends TestCase
         $this->httpClient       = $this->createMock(HttpClientInterface::class);
         $this->archiveExtractor = $this->createMock(Extractor::class);
         $this->downloader       = new Downloader($this->filesystem, $this->httpClient, $this->archiveExtractor);
-        $this->geckoMac         = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
+        $this->geckoMac         = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::MACOS, CpuArchitecture::AMD64);
         $this->geckoMacArm64    = new Driver(DriverName::GECKO, Version::fromString('0.35.0'), OperatingSystem::MACOS, CpuArchitecture::ARM64);
     }
 
@@ -48,7 +48,7 @@ class DownloaderTest extends TestCase
 
     public function testDoesNotSupportChromeDriver(): void
     {
-        $chromeDriver = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS, CpuArchitecture::X86_64);
+        $chromeDriver = new Driver(DriverName::CHROME, Version::fromString('86.0.4240.22'), OperatingSystem::MACOS, CpuArchitecture::AMD64);
         self::assertFalse($this->downloader->supports($chromeDriver));
     }
 
@@ -89,7 +89,7 @@ class DownloaderTest extends TestCase
             ->method('request')
             ->with('GET', 'https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-linux64.tar.gz');
 
-        $geckoLinux = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX, CpuArchitecture::X86_64);
+        $geckoLinux = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::LINUX, CpuArchitecture::AMD64);
         $filePath   = $this->downloader->download($geckoLinux, '.');
 
         self::assertEquals('./geckodriver', $filePath);
@@ -125,7 +125,7 @@ class DownloaderTest extends TestCase
             ->method('request')
             ->with('GET', 'https://github.com/mozilla/geckodriver/releases/download/v0.27.0/geckodriver-v0.27.0-win64.zip');
 
-        $geckoWindows = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::WINDOWS, CpuArchitecture::X86_64);
+        $geckoWindows = new Driver(DriverName::GECKO, Version::fromString('0.27.0'), OperatingSystem::WINDOWS, CpuArchitecture::AMD64);
         $filePath     = $this->downloader->download($geckoWindows, '.');
 
         self::assertEquals('./geckodriver.exe', $filePath);


### PR DESCRIPTION
This PR adds the ability to pass --arch=arm64 option when installing drivers.
The cpu architecture is detected automatically in DriverFactory::createFromBrowser().
As of today, there is no chromedriver for Linux and arm64 : 

- https://github.com/GoogleChromeLabs/chrome-for-testing/issues/1
- https://issues.chromium.org/issues/374811603