### PR TITLE
Go back to PHPStan `max` level

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,73 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset ''chromedriver'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset ''downloads'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset ''platform'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset ''url'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset string on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/DownloadUrlResolver.php
+
+		-
+			message: '#^Cannot access offset ''Beta'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/VersionResolver.php
+
+		-
+			message: '#^Cannot access offset ''Stable'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Driver/ChromeDriver/VersionResolver.php
+
+		-
+			message: '#^Cannot access offset ''version'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: src/Driver/ChromeDriver/VersionResolver.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 2
+			path: src/Driver/ChromeDriver/VersionResolver.php
+
+		-
+			message: '#^Method DBrekelmans\\BrowserDriverInstaller\\Driver\\ChromeDriver\\VersionResolver\:\:getVersionString\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Driver/ChromeDriver/VersionResolver.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Driver/ChromeDriver/VersionResolver.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 9
+	level: max
 	paths:
 		- src
 		- tests
@@ -9,3 +9,4 @@ includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
+    - phpstan-baseline.neon


### PR DESCRIPTION
Plain and simple solution to go back to PHPStan 2 `max` level.

All warnings deal with untyped responses (arrays) from [googlechromelabs.github.io](https://googlechromelabs.github.io/chrome-for-testing/) endpoints.

@dbrekelmans Do you prefer a solution with [valinor.cuyz.io](https://valinor.cuyz.io/) to check response format and enforce typing?